### PR TITLE
Dockerfile.notebookのレイヤー数削減

### DIFF
--- a/Dockerfile.notebook
+++ b/Dockerfile.notebook
@@ -2,8 +2,8 @@ FROM jupyter/datascience-notebook:python-3.8.6
 #FROM jupyter/datascience-notebook:d53a302fbcd0
 USER root
 ENV DEBCONF_NOWARNINGS yes
-RUN apt-get update
-RUN apt-get install -y libpq-dev
+RUN apt-get update \
+    && apt-get install -y libpq-dev
 USER jovyan
 RUN pip install --upgrade pip
 RUN pip install --upgrade setuptools


### PR DESCRIPTION
Dockerfileのレイヤー数は最小化することが推奨されているため、 `Dockerfile.notebook` 内の `apt-get` 関連のコマンドを1レイヤーに削減します。

参考: https://docs.docker.jp/engine/articles/dockerfile_best-practice.html#id5