### PR TITLE
Jupyter LabでRを扱えるようにする

### DIFF
--- a/dockerfiles/notebook/Dockerfile
+++ b/dockerfiles/notebook/Dockerfile
@@ -22,5 +22,6 @@ COPY Pipfile.lock .
 RUN pip install --no-cache-dir pipenv==2021.5.29 \
     && pipenv install --system \
     && rm Pipfile* \
-    && Rscript -e "install.packages(c('DBI', 'RPostgreSQL', 'rsample'), dependencies = TRUE, error = TRUE, repos='https://cran.r-project.org')"
+    && Rscript -e "install.packages(c('IRkernel', 'DBI', 'RPostgreSQL', 'rsample'), dependencies = TRUE, error = TRUE, repos='https://cran.r-project.org')" \
+    && Rscript -e "IRkernel::installspec()"
 #RUN Rscript -e "install.packages(c('DBI', 'RPostgreSQL', 'recipes'), dependencies = TRUE, error = TRUE, repos='https://cran.r-project.org')"


### PR DESCRIPTION
Jupyter LabでRが扱えなくなっていたので、扱えるようにします。
参考: https://www.tmp1024.com/install-jupyter-lab-with-r-on-mac/#toc6