### PR TITLE
Dockerイメージ内のpostgresのバージョンとlibpq-devのバージョンを同期させるCI追加

### DIFF
--- a/.github/workflows/update_packages.yml
+++ b/.github/workflows/update_packages.yml
@@ -1,0 +1,143 @@
+name: update_packages
+
+on:
+  pull_request:
+
+jobs:
+  # Dockerイメージ内のpostgresのバージョンとlibpq-devのバージョンを同期させる
+  update_libpq-dev:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Get PostgreSQL version
+        id: get_postgres_version
+        working-directory: dockerfiles/postgres
+        run: |
+          image_name=db
+          docker build -t "${image_name}" .
+          postgres_version=$(docker run ${image_name} sh -c "psql --version | sed -e 's/psql (PostgreSQL) //g'")
+          echo "PostgreSQL version:" "${postgres_version}"
+          echo "::set-output name=postgres_version::${postgres_version}"
+      - name: Update version
+        working-directory: dockerfiles/notebook
+        run: sed -i -E 's/libpq-dev=[0-9]+\.[0-9]+/libpq-dev=${{steps.get_postgres_version.outputs.postgres_version}}/g' Dockerfile
+      # 差分があったときは差分を出力する
+      - name: Show diff
+        id: diff
+        run: |
+          result=$(git diff)
+          echo "::set-output name=result::$result"
+      # 差分があったときは、コミットを作りpushする
+      - name: Push
+        env:
+          HEAD_REF: ${{github.event.pull_request.head.ref}}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' }}
+        run: |
+          git config user.name "100knocks-preprocess CI"
+          git config user.email "100knocks-preprocess-ci@example.com"
+          git add -u
+          git commit -m "Update libpq-dev"
+          git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/fix-version-${HEAD_REF}"
+      - name: Get PullRequests
+        uses: actions/github-script@v5
+        env:
+          HEAD_REF: ${{github.event.pull_request.head.ref}}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' }}
+        id: get_pull_requests
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const HEAD_REF = process.env["HEAD_REF"]
+            const pulls_list_params = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: "The-Japan-DataScientist-Society:fix-version-" + HEAD_REF,
+              base: HEAD_REF,
+              state: "open"
+            }
+            console.log("call pulls.list:", pulls_list_params)
+            const pulls = await github.paginate(github.rest.pulls.list, pulls_list_params)
+            return pulls.length
+      # pushしたブランチでPRを作る
+      - name: Create PullRequest
+        uses: actions/github-script@v5
+        env:
+          HEAD_REF: ${{github.event.pull_request.head.ref}}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' && steps.get_pull_requests.outputs.result == 0 }}
+        id: create_pull_request
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const HEAD_REF = process.env["HEAD_REF"]
+            const pulls_create_params = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: "The-Japan-DataScientist-Society:fix-version-" + HEAD_REF,
+              base: HEAD_REF,
+              title: "libpq-devアップデート #${{github.event.pull_request.number}}",
+              body: "libpq-devのバージョンをDockerイメージ内のPostgreSQLのバージョンに合わせました。このPRをマージすると元のPRに反映されます。 #${{github.event.pull_request.number}}"
+            }
+            console.log("call pulls.create:", pulls_create_params)
+            const create_pull_res = (await github.rest.pulls.create(pulls_create_params)).data
+            return create_pull_res.number
+      - name: Assign a user
+        uses: actions/github-script@v5
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' && steps.get_pull_requests.outputs.result == 0 && github.event.pull_request.user.login != 'dependabot[bot]' }}
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const issues_add_assignees_params = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{steps.create_pull_request.outputs.result}},
+              assignees: ["${{github.event.pull_request.user.login}}"]
+            }
+            console.log("call issues.addAssignees:", issues_add_assignees_params)
+            await github.rest.issues.addAssignees(issues_add_assignees_params)
+      # 既にformat修正のPRがある状態で、手動でformatを修正した場合、format修正のPRを閉じる
+      - name: Close PullRequest
+        uses: actions/github-script@v5
+        env:
+          HEAD_REF: ${{github.event.pull_request.head.ref}}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result == '' }}
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const HEAD_REF = process.env["HEAD_REF"]
+            const head_name = "fix-version-" + HEAD_REF
+            const common_params = {
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            }
+            const pulls_list_params = {
+              head: "The-Japan-DataScientist-Society:" + head_name,
+              base: HEAD_REF,
+              state: "open",
+              ...common_params
+            }
+            console.log("call pulls.list:", pulls_list_params)
+            const pulls = await github.paginate(github.rest.pulls.list, pulls_list_params)
+
+            for (const pull of pulls) {
+              const pulls_update_params = {
+                pull_number: pull.number,
+                state: "closed",
+                ...common_params
+              }
+              console.log("call pulls.update:", pulls_update_params)
+              await github.rest.pulls.update(pulls_update_params)
+              const git_deleteRef_params = {
+                ref: "heads/" + head_name,
+                ...common_params
+              }
+              console.log("call git.deleteRef:", git_deleteRef_params)
+              await github.rest.git.deleteRef(git_deleteRef_params)
+            }
+      - name: Exit
+        if: ${{ steps.diff.outputs.result != '' }}
+        run: exit 1


### PR DESCRIPTION
Dockerイメージ内のpostgresのバージョンが上がった場合、 `libpq-dev` のバージョンもそれに追従させる必要があります。
このような場合に `libpq-dev` をアップデートするPRを出すCIを追加します。

CIによって出されるPRの例: https://github.com/massongit/100knocks-preprocess/pull/15