### PR TITLE
Apple M1チップ搭載のMacの場合の注意事項追加

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,7 @@ Description
 Requirement
 ====
 - Docker Desktop(Windows 10 proffesional Edition, macOS)
+   - Apple M1チップ搭載のMacの場合は Docker Desktop 4.0.1 まで
 - Docker Toolbox(Windows 10 home edition)
 
 ※Windows 10 home でもWSL2をインストールすることでDocker Desktopが使えるようになりました！


### PR DESCRIPTION
https://github.com/The-Japan-DataScientist-Society/100knocks-preprocess/issues/98 の問題が発生しているので、Apple M1チップ搭載のMacを使っている場合は古いバージョンのDocker Desktop for macを使うようREADMEに追記します。