### PR TITLE
ARM64対応

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,6 @@ Description
 Requirement
 ====
 - Docker Desktop(Windows 10 proffesional Edition, macOS)
-   - Apple M1チップ搭載のMacの場合は Docker Desktop 4.0.1 まで
 - Docker Toolbox(Windows 10 home edition)
 
 ※Windows 10 home でもWSL2をインストールすることでDocker Desktopが使えるようになりました！

--- a/dockerfiles/notebook/Dockerfile
+++ b/dockerfiles/notebook/Dockerfile
@@ -1,4 +1,5 @@
 # https://github.com/jupyter/docker-stacks/blob/1be67b97cc695c0a480ef80c26094c0699d963b9/datascience-notebook/Dockerfile を一部コメントアウト・改変
+# TODO: jupyter/datascience-notebookがARM64対応したらそれをベースにする
 ARG OWNER=jupyter
 ARG BASE_CONTAINER=$OWNER/scipy-notebook
 #FROM $BASE_CONTAINER

--- a/dockerfiles/notebook/Dockerfile
+++ b/dockerfiles/notebook/Dockerfile
@@ -111,7 +111,7 @@ RUN set -x && \
 
 WORKDIR "${HOME}"
 
-FROM datascience-notebook
+FROM datascience-notebook AS dss-notebook
 #TODO: jupyter/datascience-notebookがARM64対応したら以下をベースにする
 #FROM jupyter/datascience-notebook:python-3.9.6
 #FROM jupyter/datascience-notebook:d53a302fbcd0

--- a/dockerfiles/notebook/Dockerfile
+++ b/dockerfiles/notebook/Dockerfile
@@ -1,10 +1,11 @@
 # https://github.com/jupyter/docker-stacks/blob/1be67b97cc695c0a480ef80c26094c0699d963b9/datascience-notebook/Dockerfile を一部コメントアウト・改変
+# TODO: jupyter/datascience-notebookがARM64対応したらそれをベースにする
 ARG OWNER=jupyter
 ARG BASE_CONTAINER=$OWNER/scipy-notebook
 #FROM $BASE_CONTAINER
-FROM $BASE_CONTAINER:python-3.9.6 AS datascience-notebook
+FROM $BASE_CONTAINER:python-3.9.6
 
-LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
+#LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 
 # Fix DL4006
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -111,10 +112,7 @@ RUN set -x && \
 
 WORKDIR "${HOME}"
 
-FROM datascience-notebook
-#TODO: jupyter/datascience-notebookがARM64対応したら以下をベースにする
-#FROM jupyter/datascience-notebook:python-3.9.6
-#FROM jupyter/datascience-notebook:d53a302fbcd0
+# ここから100本ノックオリジナル実装
 USER root
 ENV DEBCONF_NOWARNINGS yes
 

--- a/dockerfiles/notebook/Dockerfile
+++ b/dockerfiles/notebook/Dockerfile
@@ -1,5 +1,100 @@
-FROM jupyter/datascience-notebook:python-3.9.6
-#FROM jupyter/datascience-notebook:d53a302fbcd0
+# https://github.com/jupyter/docker-stacks/blob/1be67b97cc695c0a480ef80c26094c0699d963b9/datascience-notebook/Dockerfile からJuliaのパッケージインストールを抜いたもの
+FROM jupyter/scipy-notebook:python-3.9.6
+
+# Fix DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+USER root
+
+# Julia installation
+# Default values can be overridden at build time
+# (ARGS are in lower case to distinguish them from ENV)
+# Check https://julialang.org/downloads/
+ARG julia_version="1.7.0"
+
+# R pre-requisites
+RUN apt-get update --yes && \
+    apt-get install --yes --no-install-recommends \
+    fonts-dejavu \
+    gfortran \
+    gcc && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Julia dependencies
+# install Julia packages in /opt/julia instead of ${HOME}
+ENV JULIA_DEPOT_PATH=/opt/julia \
+    JULIA_PKGDIR=/opt/julia \
+    JULIA_VERSION="${julia_version}"
+
+WORKDIR /tmp
+
+# hadolint ignore=SC2046
+RUN set -x && \
+    julia_arch=$(uname -m) && \
+    julia_short_arch="${julia_arch}" && \
+    if [ "${julia_short_arch}" == "x86_64" ]; then \
+      julia_short_arch="x64"; \
+    fi; \
+    julia_installer="julia-${JULIA_VERSION}-linux-${julia_arch}.tar.gz" && \
+    julia_major_minor=$(echo "${JULIA_VERSION}" | cut -d. -f 1,2) && \
+    mkdir "/opt/julia-${JULIA_VERSION}" && \
+    wget -q "https://julialang-s3.julialang.org/bin/linux/${julia_short_arch}/${julia_major_minor}/${julia_installer}" && \
+    tar xzf "${julia_installer}" -C "/opt/julia-${JULIA_VERSION}" --strip-components=1 && \
+    rm "${julia_installer}" && \
+    ln -fs /opt/julia-*/bin/julia /usr/local/bin/julia
+
+# Show Julia where conda libraries are \
+RUN mkdir /etc/julia && \
+    echo "push!(Libdl.DL_LOAD_PATH, \"${CONDA_DIR}/lib\")" >> /etc/julia/juliarc.jl && \
+    # Create JULIA_PKGDIR \
+    mkdir "${JULIA_PKGDIR}" && \
+    chown "${NB_USER}" "${JULIA_PKGDIR}" && \
+    fix-permissions "${JULIA_PKGDIR}"
+
+USER ${NB_UID}
+
+# R packages including IRKernel which gets installed globally.
+# r-e1071: dependency of the caret R package
+RUN mamba install --quiet --yes \
+    'r-base' \
+    'r-caret' \
+    'r-crayon' \
+    'r-devtools' \
+    'r-e1071' \
+    'r-forecast' \
+    'r-hexbin' \
+    'r-htmltools' \
+    'r-htmlwidgets' \
+    'r-irkernel' \
+    'r-nycflights13' \
+    'r-randomforest' \
+    'r-rcurl' \
+    'r-rodbc' \
+    'r-rsqlite' \
+    'r-shiny' \
+    'rpy2' \
+    'unixodbc' && \
+    mamba clean --all -f -y && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"
+
+# These packages are not easy to install under arm
+RUN set -x && \
+    arch=$(uname -m) && \
+    if [ "${arch}" == "x86_64" ]; then \
+        mamba install --quiet --yes \
+            'r-rmarkdown' \
+            'r-tidymodels' \
+            'r-tidyverse' && \
+            mamba clean --all -f -y && \
+            fix-permissions "${CONDA_DIR}" && \
+            fix-permissions "/home/${NB_USER}"; \
+    fi;
+
+WORKDIR "${HOME}"
+
+# ここから100本ノックオリジナル実装
+
 USER root
 ENV DEBCONF_NOWARNINGS yes
 

--- a/dockerfiles/notebook/Dockerfile
+++ b/dockerfiles/notebook/Dockerfile
@@ -1,11 +1,10 @@
 # https://github.com/jupyter/docker-stacks/blob/1be67b97cc695c0a480ef80c26094c0699d963b9/datascience-notebook/Dockerfile を一部コメントアウト・改変
-# TODO: jupyter/datascience-notebookがARM64対応したらそれをベースにする
 ARG OWNER=jupyter
 ARG BASE_CONTAINER=$OWNER/scipy-notebook
 #FROM $BASE_CONTAINER
-FROM $BASE_CONTAINER:python-3.9.6
+FROM $BASE_CONTAINER:python-3.9.6 AS datascience-notebook
 
-#LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
+LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 
 # Fix DL4006
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -112,7 +111,10 @@ RUN set -x && \
 
 WORKDIR "${HOME}"
 
-# ここから100本ノックオリジナル実装
+FROM datascience-notebook
+#TODO: jupyter/datascience-notebookがARM64対応したら以下をベースにする
+#FROM jupyter/datascience-notebook:python-3.9.6
+#FROM jupyter/datascience-notebook:d53a302fbcd0
 USER root
 ENV DEBCONF_NOWARNINGS yes
 

--- a/dockerfiles/notebook/Dockerfile
+++ b/dockerfiles/notebook/Dockerfile
@@ -111,7 +111,7 @@ RUN set -x && \
 
 WORKDIR "${HOME}"
 
-FROM datascience-notebook AS dss-notebook
+FROM datascience-notebook
 #TODO: jupyter/datascience-notebookがARM64対応したら以下をベースにする
 #FROM jupyter/datascience-notebook:python-3.9.6
 #FROM jupyter/datascience-notebook:d53a302fbcd0

--- a/dockerfiles/notebook/Dockerfile
+++ b/dockerfiles/notebook/Dockerfile
@@ -1,5 +1,10 @@
-# https://github.com/jupyter/docker-stacks/blob/1be67b97cc695c0a480ef80c26094c0699d963b9/datascience-notebook/Dockerfile からJuliaのパッケージインストールを抜いたもの
-FROM jupyter/scipy-notebook:python-3.9.6
+# https://github.com/jupyter/docker-stacks/blob/1be67b97cc695c0a480ef80c26094c0699d963b9/datascience-notebook/Dockerfile を一部コメントアウト・改変
+ARG OWNER=jupyter
+ARG BASE_CONTAINER=$OWNER/scipy-notebook
+#FROM $BASE_CONTAINER
+FROM $BASE_CONTAINER:python-3.9.6
+
+#LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 
 # Fix DL4006
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -91,10 +96,22 @@ RUN set -x && \
             fix-permissions "/home/${NB_USER}"; \
     fi;
 
+# Add Julia packages.
+# Install IJulia as jovyan and then move the kernelspec out
+# to the system share location. Avoids problems with runtime UID change not
+# taking effect properly on the .local folder in the jovyan home dir.
+#RUN julia -e 'import Pkg; Pkg.update()' && \
+#    julia -e 'import Pkg; Pkg.add("HDF5")' && \
+#    julia -e 'using Pkg; pkg"add IJulia"; pkg"precompile"' && \
+#    # move kernelspec out of home \
+#    mv "${HOME}/.local/share/jupyter/kernels/julia"* "${CONDA_DIR}/share/jupyter/kernels/" && \
+#    chmod -R go+rx "${CONDA_DIR}/share/jupyter" && \
+#    rm -rf "${HOME}/.local" && \
+#    fix-permissions "${JULIA_PKGDIR}" "${CONDA_DIR}/share/jupyter"
+
 WORKDIR "${HOME}"
 
 # ここから100本ノックオリジナル実装
-
 USER root
 ENV DEBCONF_NOWARNINGS yes
 

--- a/dockerfiles/notebook/Dockerfile
+++ b/dockerfiles/notebook/Dockerfile
@@ -1,5 +1,4 @@
-# https://github.com/jupyter/docker-stacks/blob/1be67b97cc695c0a480ef80c26094c0699d963b9/datascience-notebook/Dockerfile を一部コメントアウト・改変
-# TODO: jupyter/datascience-notebookがARM64対応したらそれをベースにする
+#https://github.com/jupyter/docker-stacks/blob/1be67b97cc695c0a480ef80c26094c0699d963b9/datascience-notebook/Dockerfile を一部コメントアウト・改変
 ARG OWNER=jupyter
 ARG BASE_CONTAINER=$OWNER/scipy-notebook
 #FROM $BASE_CONTAINER
@@ -113,6 +112,9 @@ RUN set -x && \
 WORKDIR "${HOME}"
 
 # ここから100本ノックオリジナル実装
+#TODO: jupyter/datascience-notebookがARM64対応したら以下をベースにする
+#FROM jupyter/datascience-notebook:python-3.9.6
+#FROM jupyter/datascience-notebook:d53a302fbcd0
 USER root
 ENV DEBCONF_NOWARNINGS yes
 


### PR DESCRIPTION
fix https://github.com/The-Japan-DataScientist-Society/100knocks-preprocess/issues/98

`jupyter/datascience-notebook` をarm64でビルドしようとすると以下のJuliaのパッケージインストールで落ちますが、100本ノックではJuliaは使用していません。
https://github.com/jupyter/docker-stacks/blob/1be67b97cc695c0a480ef80c26094c0699d963b9/datascience-notebook/Dockerfile#L99-L110

従って、上記の処理を抜いた状態でビルドすることでARM64対応します。