### PR TITLE
Python: 解答コードの整形

### DIFF
--- a/docker/work/answer/ans_preprocess_knock_Python.ipynb
+++ b/docker/work/answer/ans_preprocess_knock_Python.ipynb
@@ -29,7 +29,6 @@
     "import os\n",
     "import pandas as pd\n",
     "import numpy as np\n",
-    "from datetime import datetime, date\n",
     "from dateutil.relativedelta import relativedelta\n",
     "import math\n",
     "import psycopg2\n",
@@ -54,7 +53,7 @@
     "df_product = pd.read_sql(sql='select * from product', con=conn)\n",
     "df_receipt = pd.read_sql(sql='select * from receipt', con=conn)\n",
     "df_store = pd.read_sql(sql='select * from store', con=conn)\n",
-    "df_geocode = pd.read_sql(sql='select * from geocode', con=conn)"
+    "df_geocode = pd.read_sql(sql='select * from geocode', con=conn)\n"
    ]
   },
   {
@@ -542,8 +541,8 @@
     }
    ],
    "source": [
-    "df_receipt[['sales_ymd', 'customer_id', 'product_cd', 'amount']]. \\\n",
-    "                        rename(columns={'sales_ymd': 'sales_date'}).head(10)"
+    "df_receipt[['sales_ymd', 'customer_id', 'product_cd', 'amount']] \\\n",
+    "    .rename(columns={'sales_ymd': 'sales_date'}).head(10)\n"
    ]
   },
   {
@@ -698,8 +697,8 @@
     }
    ],
    "source": [
-    "df_receipt[['sales_ymd', 'customer_id', 'product_cd', 'amount']]. \\\n",
-    "                                query('customer_id == \"CS018205000001\"')"
+    "df_receipt[['sales_ymd', 'customer_id', 'product_cd', 'amount']] \\\n",
+    "    .query('customer_id == \"CS018205000001\"')\n"
    ]
   },
   {
@@ -784,7 +783,7 @@
    ],
    "source": [
     "df_receipt[['sales_ymd', 'customer_id', 'product_cd', 'amount']] \\\n",
-    "            .query('customer_id == \"CS018205000001\" & amount >= 1000')"
+    "    .query('customer_id == \"CS018205000001\" & amount >= 1000')\n"
    ]
   },
   {
@@ -890,8 +889,8 @@
     }
    ],
    "source": [
-    "df_receipt[['sales_ymd', 'customer_id', 'product_cd', 'quantity', 'amount']].\\\n",
-    "    query('customer_id == \"CS018205000001\" & (amount >= 1000 | quantity >=5)')"
+    "df_receipt[['sales_ymd', 'customer_id', 'product_cd', 'quantity', 'amount']] \\\n",
+    "    .query('customer_id == \"CS018205000001\" & (amount >= 1000 | quantity >=5)')\n"
    ]
   },
   {
@@ -960,7 +959,7 @@
    ],
    "source": [
     "df_receipt[['sales_ymd', 'customer_id', 'product_cd', 'amount']] \\\n",
-    "    .query('customer_id == \"CS018205000001\" & 1000 <= amount <= 2000')"
+    "    .query('customer_id == \"CS018205000001\" & 1000 <= amount <= 2000')\n"
    ]
   },
   {
@@ -1117,7 +1116,7 @@
    ],
    "source": [
     "df_receipt[['sales_ymd', 'customer_id', 'product_cd', 'amount']] \\\n",
-    "    .query('customer_id == \"CS018205000001\" & product_cd != \"P071401019\"')"
+    "    .query('customer_id == \"CS018205000001\" & product_cd != \"P071401019\"')\n"
    ]
   },
   {
@@ -1463,7 +1462,7 @@
     }
    ],
    "source": [
-    "df_store.query(\"store_cd.str.startswith('S14')\", engine='python').head(10)"
+    "df_store.query('store_cd.str.startswith(\"S14\")', engine='python').head(10)"
    ]
   },
   {
@@ -1702,7 +1701,7 @@
     }
    ],
    "source": [
-    "df_customer.query(\"customer_id.str.endswith('1')\", engine='python').head(10)"
+    "df_customer.query('customer_id.str.endswith(\"1\")', engine='python').head(10)"
    ]
   },
   {
@@ -1946,7 +1945,7 @@
     }
    ],
    "source": [
-    "df_store.query(\"address.str.contains('横浜市')\", engine='python')"
+    "df_store.query('address.str.contains(\"横浜市\")', engine='python')"
    ]
   },
   {
@@ -2185,8 +2184,8 @@
     }
    ],
    "source": [
-    "df_customer.query(\"status_cd.str.contains('^[A-F]', regex=True)\", \n",
-    "                  engine='python').head(10)"
+    "df_customer.query('status_cd.str.contains(r\"^[A-F]\")',\n",
+    "                  engine='python').head(10)\n"
    ]
   },
   {
@@ -2425,7 +2424,8 @@
     }
    ],
    "source": [
-    "df_customer.query(\"status_cd.str.contains('[1-9]$', regex=True)\", engine='python').head(10)"
+    "df_customer.query('status_cd.str.contains(r\"[1-9]$\")',\n",
+    "                  engine='python').head(10)\n"
    ]
   },
   {
@@ -2664,8 +2664,8 @@
     }
    ],
    "source": [
-    "df_customer.query(\"status_cd.str.contains('^[A-F].*[1-9]$', regex=True)\", \n",
-    "                  engine='python').head(10)"
+    "df_customer.query('status_cd.str.contains(r\"^[A-F].*[1-9]$\")',\n",
+    "                  engine='python').head(10)\n"
    ]
   },
   {
@@ -3277,8 +3277,8 @@
     }
    ],
    "source": [
-    "df_store.query(\"tel_no.str.contains('^[0-9]{3}-[0-9]{3}-[0-9]{4}$',regex=True)\", \n",
-    "               engine='python')"
+    "df_store.query('tel_no.str.contains(r\"^[0-9]{3}-[0-9]{3}-[0-9]{4}$\")',\n",
+    "               engine='python')\n"
    ]
   },
   {
@@ -3517,7 +3517,7 @@
     }
    ],
    "source": [
-    "df_customer.sort_values('birth_day', ascending=True).head(10)"
+    "df_customer.sort_values('birth_day', ascending=True).head(10)\n"
    ]
   },
   {
@@ -3883,11 +3883,12 @@
     }
    ],
    "source": [
-    "df_tmp = pd.concat([df_receipt[['customer_id', 'amount']] \n",
-    "                     ,df_receipt['amount'].rank(method='min', \n",
-    "                                                ascending=False)], axis=1)\n",
+    "df_tmp = pd.concat(\n",
+    "    [df_receipt[['customer_id', 'amount']],\n",
+    "     df_receipt['amount'].rank(method='min', ascending=False)],\n",
+    "    axis=1)\n",
     "df_tmp.columns = ['customer_id', 'amount', 'ranking']\n",
-    "df_tmp.sort_values('ranking', ascending=True).head(10)"
+    "df_tmp.sort_values('ranking', ascending=True).head(10)\n"
    ]
   },
   {
@@ -4014,11 +4015,12 @@
     }
    ],
    "source": [
-    "df_tmp = pd.concat([df_receipt[['customer_id', 'amount']] \n",
-    "                     ,df_receipt['amount'].rank(method='first', \n",
-    "                                                ascending=False)], axis=1)\n",
+    "df_tmp = pd.concat(\n",
+    "    [df_receipt[['customer_id', 'amount']],\n",
+    "     df_receipt['amount'].rank(method='first', ascending=False)],\n",
+    "    axis=1)\n",
     "df_tmp.columns = ['customer_id', 'amount', 'ranking']\n",
-    "df_tmp.sort_values('ranking', ascending=True).head(10)"
+    "df_tmp.sort_values('ranking', ascending=True).head(10)\n"
    ]
   },
   {
@@ -4496,7 +4498,7 @@
    ],
    "source": [
     "df_receipt.groupby('store_cd').agg({'amount':'sum', \n",
-    "                                    'quantity':'sum'}).reset_index()"
+    "                                    'quantity':'sum'}).reset_index()\n"
    ]
   },
   {
@@ -4612,7 +4614,7 @@
     }
    ],
    "source": [
-    "df_receipt.groupby('customer_id').sales_ymd.max().reset_index().head(10)"
+    "df_receipt.groupby('customer_id')['sales_ymd'].max().reset_index().head(10)"
    ]
   },
   {
@@ -4722,7 +4724,7 @@
     }
    ],
    "source": [
-    "df_receipt.groupby('customer_id').agg({'sales_ymd':'min'}).head(10)"
+    "df_receipt.groupby('customer_id').agg({'sales_ymd': 'min'}).head(10)"
    ]
   },
   {
@@ -4849,10 +4851,10 @@
     }
    ],
    "source": [
-    "df_tmp = df_receipt.groupby('customer_id'). \\\n",
-    "                agg({'sales_ymd':['max','min']}).reset_index()\n",
-    "df_tmp.columns = [\"_\".join(pair) for pair in df_tmp.columns]\n",
-    "df_tmp.query('sales_ymd_max != sales_ymd_min').head(10)"
+    "df_tmp = df_receipt.groupby('customer_id').agg(\n",
+    "    {'sales_ymd': ['max', 'min']}).reset_index()\n",
+    "df_tmp.columns = ['_'.join(pair) for pair in df_tmp.columns]\n",
+    "df_tmp.query('sales_ymd_max != sales_ymd_min').head(10)\n"
    ]
   },
   {
@@ -4938,8 +4940,8 @@
     }
    ],
    "source": [
-    "df_receipt.groupby('store_cd').agg({'amount':'mean'}).reset_index(). \\\n",
-    "                            sort_values('amount', ascending=False).head(5)"
+    "df_receipt.groupby('store_cd').agg({'amount': 'mean'}).reset_index() \\\n",
+    "    .sort_values('amount', ascending=False).head(5)\n"
    ]
   },
   {
@@ -5025,8 +5027,8 @@
     }
    ],
    "source": [
-    "df_receipt.groupby('store_cd').agg({'amount':'median'}).reset_index(). \\\n",
-    "                            sort_values('amount', ascending=False).head(5)"
+    "df_receipt.groupby('store_cd').agg({'amount': 'median'}).reset_index() \\\n",
+    "    .sort_values('amount', ascending=False).head(5)\n"
    ]
   },
   {
@@ -5468,8 +5470,8 @@
     }
    ],
    "source": [
-    "df_receipt.groupby('store_cd').product_cd. \\\n",
-    "            apply(lambda x: x.mode()).reset_index()"
+    "df_receipt.groupby('store_cd')['product_cd'].apply(\n",
+    "    lambda x: x.mode()).reset_index()\n"
    ]
   },
   {
@@ -5555,8 +5557,8 @@
     }
    ],
    "source": [
-    "df_receipt.groupby('store_cd').amount.var(ddof=0).reset_index(). \\\n",
-    "                            sort_values('amount', ascending=False).head(5)"
+    "df_receipt.groupby('store_cd')['amount'].var(ddof=0).reset_index() \\\n",
+    "    .sort_values('amount', ascending=False).head(5)\n"
    ]
   },
   {
@@ -5657,8 +5659,8 @@
     }
    ],
    "source": [
-    "df_receipt.groupby('store_cd').amount.std(ddof=0).reset_index(). \\\n",
-    "                            sort_values('amount', ascending=False).head(5)"
+    "df_receipt.groupby('store_cd')['amount'].std(ddof=0).reset_index() \\\n",
+    "    .sort_values('amount', ascending=False).head(5)\n"
    ]
   },
   {
@@ -5687,7 +5689,7 @@
    ],
    "source": [
     "# コード例1\n",
-    "np.percentile(df_receipt['amount'], q=[25, 50, 75,100])"
+    "np.percentile(df_receipt['amount'], q=[25, 50, 75, 100])\n"
    ]
   },
   {
@@ -5713,7 +5715,7 @@
    ],
    "source": [
     "# コード例2\n",
-    "df_receipt.amount.quantile(q=np.arange(5)/4)"
+    "df_receipt['amount'].quantile(q=np.arange(5)/4)\n"
    ]
   },
   {
@@ -5847,8 +5849,8 @@
     }
    ],
    "source": [
-    "df_receipt.groupby('store_cd').amount.mean(). \\\n",
-    "                    reset_index().query('amount >= 330')"
+    "df_receipt.groupby('store_cd')['amount'].mean() \\\n",
+    "    .reset_index().query('amount >= 330')\n"
    ]
   },
   {
@@ -5877,8 +5879,8 @@
    ],
    "source": [
     "# queryを使わない書き方\n",
-    "df_receipt[~df_receipt['customer_id'].str.startswith(\"Z\")]. \\\n",
-    "                            groupby('customer_id').amount.sum().mean()"
+    "df_receipt[~df_receipt['customer_id'].str.startswith('Z')] \\\n",
+    "    .groupby('customer_id').amount.sum().mean()\n"
    ]
   },
   {
@@ -5899,8 +5901,9 @@
    ],
    "source": [
     "# queryを使う書き方\n",
-    "df_receipt.query('not customer_id.str.startswith(\"Z\")', \n",
-    "                 engine='python').groupby('customer_id').amount.sum().mean()"
+    "df_receipt.query(\n",
+    "    'not customer_id.str.startswith(\"Z\")', engine='python') \\\n",
+    "    .groupby('customer_id')['amoount'].sum().mean()\n"
    ]
   },
   {
@@ -6016,10 +6019,11 @@
     }
    ],
    "source": [
-    "df_receipt_tmp = df_receipt[~df_receipt['customer_id'].str.startswith(\"Z\")]\n",
-    "amount_mean = df_receipt_tmp.groupby('customer_id').amount.sum().mean()\n",
-    "df_amount_sum = df_receipt_tmp.groupby('customer_id').amount.sum().reset_index()\n",
-    "df_amount_sum[df_amount_sum['amount'] >= amount_mean].head(10)"
+    "df_receipt_tmp = df_receipt[~df_receipt['customer_id'].str.startswith('Z')]\n",
+    "amount_mean = df_receipt_tmp.groupby('customer_id')['amount'].sum().mean()\n",
+    "df_amount_sum = (df_receipt_tmp.groupby('customer_id')['amount'].sum()\n",
+    "                 .reset_index())\n",
+    "df_amount_sum[df_amount_sum['amount'] >= amount_mean].head(10)\n"
    ]
   },
   {
@@ -6235,8 +6239,8 @@
     }
    ],
    "source": [
-    "pd.merge(df_receipt, df_store[['store_cd','store_name']], \n",
-    "         how='inner', on='store_cd').head(10)"
+    "pd.merge(df_receipt, df_store[['store_cd', 'store_name']],\n",
+    "         how='inner', on='store_cd').head(10)\n"
    ]
   },
   {
@@ -6419,9 +6423,9 @@
     }
    ],
    "source": [
-    "pd.merge(df_product\n",
-    "         , df_category[['category_small_cd','category_small_name']]\n",
-    "         , how='inner', on='category_small_cd').head(10)"
+    "pd.merge(df_product,\n",
+    "         df_category[['category_small_cd', 'category_small_name']],\n",
+    "         how='inner', on='category_small_cd').head(10)\n"
    ]
   },
   {
@@ -6537,12 +6541,12 @@
     }
    ],
    "source": [
-    "df_amount_sum = df_receipt.groupby('customer_id').amount.sum().reset_index()\n",
-    "df_tmp = df_customer. \\\n",
-    "            query('gender_cd == \"1\" and not customer_id.str.startswith(\"Z\")', \n",
-    "                  engine='python')\n",
-    "pd.merge(df_tmp['customer_id'], df_amount_sum, \n",
-    "         how='left', on='customer_id').fillna(0).head(10)"
+    "df_amount_sum = df_receipt.groupby('customer_id')['amount'].sum().reset_index()\n",
+    "df_tmp = df_customer.query(\n",
+    "    'gender_cd == \"1\" and not customer_id.str.startswith(\"Z\")',\n",
+    "    engine='python')\n",
+    "pd.merge(df_tmp['customer_id'], df_amount_sum,\n",
+    "         how='left', on='customer_id').fillna(0).head(10)\n"
    ]
   },
   {
@@ -6837,16 +6841,17 @@
     }
    ],
    "source": [
-    "df_sum = df_receipt.groupby('customer_id').amount.sum().reset_index()\n",
+    "df_sum = df_receipt.groupby('customer_id')['amount'].sum().reset_index()\n",
     "df_sum = df_sum.query('not customer_id.str.startswith(\"Z\")', engine='python')\n",
     "df_sum = df_sum.sort_values('amount', ascending=False).head(20)\n",
     "\n",
-    "df_cnt = df_receipt[~df_receipt.duplicated(subset=['customer_id', 'sales_ymd'])]\n",
+    "df_cnt = df_receipt[\n",
+    "    ~df_receipt.duplicated(subset=['customer_id', 'sales_ymd'])]\n",
     "df_cnt = df_cnt.query('not customer_id.str.startswith(\"Z\")', engine='python')\n",
-    "df_cnt = df_cnt.groupby('customer_id').sales_ymd.count().reset_index()\n",
+    "df_cnt = df_cnt.groupby('customer_id')['sales_ymd'].count().reset_index()\n",
     "df_cnt = df_cnt.sort_values('sales_ymd', ascending=False).head(20)\n",
     "\n",
-    "pd.merge(df_sum, df_cnt, how='outer', on='customer_id')"
+    "pd.merge(df_sum, df_cnt, how='outer', on='customer_id')\n"
    ]
   },
   {
@@ -6879,7 +6884,7 @@
     "\n",
     "df_store_tmp['key'] = 0\n",
     "df_product_tmp['key'] = 0\n",
-    "len(pd.merge(df_store_tmp, df_product_tmp, how='outer', on='key'))"
+    "len(pd.merge(df_store_tmp, df_product_tmp, how='outer', on='key'))\n"
    ]
   },
   {
@@ -7028,14 +7033,16 @@
     }
    ],
    "source": [
-    "df_sales_amount_by_date = df_receipt[['sales_ymd', 'amount']].\\\n",
-    "                                groupby('sales_ymd').sum().reset_index()\n",
-    "df_sales_amount_by_date = pd.concat([df_sales_amount_by_date, \n",
+    "df_sales_amount_by_date = (df_receipt[['sales_ymd', 'amount']]\n",
+    "                           .groupby('sales_ymd').sum()\n",
+    "                           .reset_index())\n",
+    "df_sales_amount_by_date = pd.concat([df_sales_amount_by_date,\n",
     "                                     df_sales_amount_by_date.shift()], axis=1)\n",
-    "df_sales_amount_by_date.columns = ['sales_ymd','amount','lag_ymd','lag_amount']\n",
-    "df_sales_amount_by_date['diff_amount'] = \\\n",
-    "    df_sales_amount_by_date['amount'] - df_sales_amount_by_date['lag_amount']\n",
-    "df_sales_amount_by_date.head(10)"
+    "df_sales_amount_by_date.columns = [\n",
+    "    'sales_ymd', 'amount', 'lag_ymd', 'lag_amount']\n",
+    "df_sales_amount_by_date['diff_amount'] = (\n",
+    "    df_sales_amount_by_date['amount'] - df_sales_amount_by_date['lag_amount'])\n",
+    "df_sales_amount_by_date.head(10)\n"
    ]
   },
   {
@@ -7174,18 +7181,19 @@
    ],
    "source": [
     "# コード例1:縦持ちケース\n",
-    "df_sales_amount_by_date = df_receipt[['sales_ymd', 'amount']]. \\\n",
-    "                                groupby('sales_ymd').sum().reset_index()\n",
+    "df_sales_amount_by_date = (df_receipt[['sales_ymd', 'amount']]\n",
+    "                           .groupby('sales_ymd').sum()\n",
+    "                           .reset_index())\n",
     "for i in range(1, 4):\n",
     "    if i == 1:\n",
-    "        df_lag = pd.concat([df_sales_amount_by_date, \n",
-    "                            df_sales_amount_by_date.shift(i)],axis=1)\n",
+    "        df_lag = pd.concat([df_sales_amount_by_date,\n",
+    "                            df_sales_amount_by_date.shift(i)], axis=1)\n",
     "    else:\n",
-    "        df_lag = df_lag.append(pd.concat([df_sales_amount_by_date, \n",
+    "        df_lag = df_lag.append(pd.concat([df_sales_amount_by_date,\n",
     "                                          df_sales_amount_by_date.shift(i)],\n",
-    "                                          axis=1))\n",
+    "                                         axis=1))\n",
     "df_lag.columns = ['sales_ymd', 'amount', 'lag_ymd', 'lag_amount']\n",
-    "df_lag.dropna().sort_values(['sales_ymd','lag_ymd']).head(10)"
+    "df_lag.dropna().sort_values(['sales_ymd', 'lag_ymd']).head(10)\n"
    ]
   },
   {
@@ -7372,17 +7380,18 @@
    ],
    "source": [
     "# コード例2:横持ちケース\n",
-    "df_sales_amount_by_date = df_receipt[['sales_ymd', 'amount']].\\\n",
-    "                                groupby('sales_ymd').sum().reset_index()\n",
+    "df_sales_amount_by_date = (df_receipt[['sales_ymd', 'amount']]\n",
+    "                           .groupby('sales_ymd').sum()\n",
+    "                           .reset_index())\n",
     "for i in range(1, 4):\n",
     "    if i == 1:\n",
-    "        df_lag = pd.concat([df_sales_amount_by_date, \n",
-    "                            df_sales_amount_by_date.shift(i)],axis=1)\n",
+    "        df_lag = pd.concat([df_sales_amount_by_date,\n",
+    "                            df_sales_amount_by_date.shift(i)], axis=1)\n",
     "    else:\n",
-    "        df_lag = pd.concat([df_lag, df_sales_amount_by_date.shift(i)],axis=1)\n",
-    "df_lag.columns = ['sales_ymd', 'amount', 'lag_ymd_1', 'lag_amount_1', \n",
+    "        df_lag = pd.concat([df_lag, df_sales_amount_by_date.shift(i)], axis=1)\n",
+    "df_lag.columns = ['sales_ymd', 'amount', 'lag_ymd_1', 'lag_amount_1',\n",
     "                  'lag_ymd_2', 'lag_amount_2', 'lag_ymd_3', 'lag_amount_3']\n",
-    "df_lag.dropna().sort_values(['sales_ymd']).head(10)"
+    "df_lag.dropna().sort_values(['sales_ymd']).head(10)\n"
    ]
   },
   {
@@ -7515,12 +7524,13 @@
    ],
    "source": [
     "# コード例1\n",
-    "df_tmp = pd.merge(df_receipt, df_customer, how ='inner', on=\"customer_id\")\n",
+    "df_tmp = pd.merge(df_receipt, df_customer, how='inner', on='customer_id')\n",
     "df_tmp['era'] = df_tmp['age'].apply(lambda x: math.floor(x / 10) * 10)\n",
-    "df_sales_summary = pd.pivot_table(df_tmp, index='era', columns='gender_cd', \n",
+    "\n",
+    "df_sales_summary = pd.pivot_table(df_tmp, index='era', columns='gender_cd',\n",
     "                                  values='amount', aggfunc='sum').reset_index()\n",
     "df_sales_summary.columns = ['era', 'male', 'female', 'unknown']\n",
-    "df_sales_summary"
+    "df_sales_summary\n"
    ]
   },
   {
@@ -7643,9 +7653,10 @@
    ],
    "source": [
     "# コード例2\n",
-    "df_tmp = pd.merge(df_receipt, df_customer, how ='inner', on=\"customer_id\")\n",
-    "df_tmp['era'] = np.floor(df_tmp['age'] / 10).astype(int)  * 10\n",
-    "df_sales_summary = pd.pivot_table(df_tmp, index='era', columns='gender_cd', \n",
+    "df_tmp = pd.merge(df_receipt, df_customer, how='inner', on='customer_id')\n",
+    "df_tmp['era'] = np.floor(df_tmp['age'] / 10).astype(int) * 10\n",
+    "\n",
+    "df_sales_summary = pd.pivot_table(df_tmp, index='era', columns='gender_cd',\n",
     "                                  values='amount', aggfunc='sum').reset_index()\n",
     "df_sales_summary.columns = ['era', 'male', 'female', 'unknown']\n",
     "df_sales_summary"
@@ -7665,9 +7676,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_sales_summary = df_sales_summary.set_index('era'). \\\n",
-    "    stack().reset_index().replace({'female':'01','male':'00','unknown':'99'}). \\\n",
-    "    rename(columns={'level_1':'gender_cd', 0: 'amount'})"
+    "df_sales_summary = (df_sales_summary.set_index('era').stack().reset_index()\n",
+    "                    .replace({'female': '01', 'male': '00', 'unknown': '99'})\n",
+    "                    .rename(columns={'level_1': 'gender_cd', 0: 'amount'}))\n"
    ]
   },
   {
@@ -8009,7 +8020,7 @@
    "source": [
     "pd.concat([df_customer['customer_id'],\n",
     "           pd.to_datetime(df_customer['birth_day']).dt.strftime('%Y%m%d')],\n",
-    "          axis = 1).head(10)"
+    "          axis=1).head(10)\n"
    ]
   },
   {
@@ -8126,7 +8137,8 @@
    ],
    "source": [
     "pd.concat([df_customer['customer_id'],\n",
-    "           pd.to_datetime(df_customer['application_date'])], axis=1).head(10)"
+    "           pd.to_datetime(df_customer['application_date'])],\n",
+    "          axis=1).head(10)\n"
    ]
   },
   {
@@ -8255,7 +8267,7 @@
    "source": [
     "pd.concat([df_receipt[['receipt_no', 'receipt_sub_no']],\n",
     "           pd.to_datetime(df_receipt['sales_ymd'].astype('str'))],\n",
-    "          axis=1).head(10)"
+    "          axis=1).head(10)\n"
    ]
   },
   {
@@ -8383,8 +8395,8 @@
    ],
    "source": [
     "pd.concat([df_receipt[['receipt_no', 'receipt_sub_no']],\n",
-    "           pd.to_datetime(df_receipt['sales_epoch'], unit='s')], \n",
-    "           axis=1).head(10)"
+    "           pd.to_datetime(df_receipt['sales_epoch'], unit='s')],\n",
+    "          axis=1).head(10)\n"
    ]
   },
   {
@@ -8513,7 +8525,7 @@
    "source": [
     "pd.concat([df_receipt[['receipt_no', 'receipt_sub_no']],\n",
     "           pd.to_datetime(df_receipt['sales_epoch'], unit='s').dt.year],\n",
-    "           axis=1).head(10)"
+    "          axis=1).head(10)\n"
    ]
   },
   {
@@ -8641,9 +8653,10 @@
    ],
    "source": [
     "# dt.monthでも月を取得できるが、ここでは0埋め２桁で取り出すためstrftimeを利用している\n",
-    "pd.concat([df_receipt[['receipt_no', 'receipt_sub_no']],\n",
-    "           pd.to_datetime(df_receipt['sales_epoch'], unit='s'). \\\n",
-    "           dt.strftime('%m')],axis=1).head(10)"
+    "pd.concat(\n",
+    "    [df_receipt[['receipt_no', 'receipt_sub_no']],\n",
+    "     pd.to_datetime(df_receipt['sales_epoch'], unit='s').dt.strftime('%m')],\n",
+    "    axis=1).head(10)\n"
    ]
   },
   {
@@ -8771,9 +8784,10 @@
    ],
    "source": [
     "# dt.dayでも日を取得できるが、ここでは0埋め２桁で取り出すためstrftimeを利用している\n",
-    "pd.concat([df_receipt[['receipt_no', 'receipt_sub_no']],\n",
-    "           pd.to_datetime(df_receipt['sales_epoch'], unit='s'). \\\n",
-    "           dt.strftime('%d')],axis=1).head(10)"
+    "pd.concat(\n",
+    "    [df_receipt[['receipt_no', 'receipt_sub_no']],\n",
+    "     pd.to_datetime(df_receipt['sales_epoch'], unit='s').dt.strftime('%d')],\n",
+    "    axis=1).head(10)\n"
    ]
   },
   {
@@ -8901,13 +8915,14 @@
    ],
    "source": [
     "# コード例1\n",
-    "df_sales_amount = df_receipt.query('not customer_id.str.startswith(\"Z\")', \n",
+    "df_sales_amount = df_receipt.query('not customer_id.str.startswith(\"Z\")',\n",
     "                                   engine='python')\n",
-    "df_sales_amount = df_sales_amount[['customer_id', 'amount']]. \\\n",
-    "                                    groupby('customer_id').sum().reset_index()\n",
-    "df_sales_amount['sales_flg'] = df_sales_amount['amount']. \\\n",
-    "                                    apply(lambda x: 1 if x > 2000 else 0)\n",
-    "df_sales_amount.head(10)"
+    "df_sales_amount = (df_sales_amount[['customer_id', 'amount']]\n",
+    "                   .groupby('customer_id').sum()\n",
+    "                   .reset_index())\n",
+    "df_sales_amount['sales_flg'] = (df_sales_amount['amount']\n",
+    "                                .apply(lambda x: 1 if x > 2000 else 0))\n",
+    "df_sales_amount.head(10)\n"
    ]
   },
   {
@@ -9027,12 +9042,13 @@
    ],
    "source": [
     "# コード例2（np.whereの活用）\n",
-    "df_sales_amount = df_receipt.query('not customer_id.str.startswith(\"Z\")', \n",
+    "df_sales_amount = df_receipt.query('not customer_id.str.startswith(\"Z\")',\n",
     "                                   engine='python')\n",
-    "df_sales_amount = df_sales_amount[['customer_id', 'amount']]. \\\n",
-    "                                    groupby('customer_id').sum().reset_index()\n",
+    "df_sales_amount = (df_sales_amount[['customer_id', 'amount']]\n",
+    "                   .groupby('customer_id').sum()\n",
+    "                   .reset_index())\n",
     "df_sales_amount['sales_flg'] = np.where(df_sales_amount['amount'] > 2000, 1, 0)\n",
-    "df_sales_amount.head(10)"
+    "df_sales_amount.head(10)\n"
    ]
   },
   {
@@ -9104,11 +9120,11 @@
    "source": [
     "# コード例1\n",
     "df_tmp = df_customer[['customer_id', 'postal_cd']].copy()\n",
-    "df_tmp['postal_flg'] = df_tmp['postal_cd']. \\\n",
-    "                        apply(lambda x: 1 if 100 <= int(x[0:3]) <= 209 else 0)\n",
+    "df_tmp['postal_flg'] = df_tmp['postal_cd'].apply(\n",
+    "    lambda x: 1 if 100 <= int(x[0:3]) <= 209 else 0)\n",
     "\n",
-    "pd.merge(df_tmp, df_receipt, how='inner', on='customer_id'). \\\n",
-    "    groupby('postal_flg').agg({'customer_id':'nunique'})"
+    "pd.merge(df_tmp, df_receipt, how='inner', on='customer_id') \\\n",
+    "    .groupby('postal_flg').agg({'customer_id': 'nunique'})\n"
    ]
   },
   {
@@ -9174,8 +9190,8 @@
     "df_tmp = df_customer[['customer_id', 'postal_cd']].copy()\n",
     "df_tmp['postal_flg'] = np.where(df_tmp['postal_cd'].str[0:3].astype(int)\n",
     "                                .between(100, 209), 1, 0)\n",
-    "pd.merge(df_tmp, df_receipt, how='inner', on='customer_id'). \\\n",
-    "    groupby('postal_flg').agg({'customer_id':'nunique'})"
+    "pd.merge(df_tmp, df_receipt, how='inner', on='customer_id') \\\n",
+    "    .groupby('postal_flg').agg({'customer_id': 'nunique'})\n"
    ]
   },
   {
@@ -9302,11 +9318,12 @@
     }
    ],
    "source": [
-    "pd.concat([df_customer[['customer_id', 'address']], \n",
+    "pd.concat([df_customer[['customer_id', 'address']],\n",
     "           df_customer['address'].str[0:3].map({'埼玉県': '11',\n",
-    "                                                '千葉県':'12', \n",
-    "                                                '東京都':'13', \n",
-    "                                                '神奈川':'14'})],axis=1).head(10)"
+    "                                                '千葉県': '12',\n",
+    "                                                '東京都': '13',\n",
+    "                                                '神奈川': '14'})],\n",
+    "          axis=1).head(10)\n"
    ]
   },
   {
@@ -9439,11 +9456,13 @@
    ],
    "source": [
     "# コード例1\n",
-    "df_sales_amount = df_receipt[['customer_id', 'amount']]. \\\n",
-    "                        groupby('customer_id').sum().reset_index()\n",
+    "df_sales_amount = (df_receipt[['customer_id', 'amount']]\n",
+    "                   .groupby('customer_id').sum()\n",
+    "                   .reset_index())\n",
     "pct25 = np.quantile(df_sales_amount['amount'], 0.25)\n",
     "pct50 = np.quantile(df_sales_amount['amount'], 0.5)\n",
     "pct75 = np.quantile(df_sales_amount['amount'], 0.75)\n",
+    "\n",
     "\n",
     "def pct_group(x):\n",
     "    if x < pct25:\n",
@@ -9455,8 +9474,10 @@
     "    elif pct75 <= x:\n",
     "        return 4\n",
     "\n",
-    "df_sales_amount['pct_group'] = df_sales_amount['amount'].apply(lambda x: pct_group(x))\n",
-    "df_sales_amount.head(10)"
+    "\n",
+    "df_sales_amount['pct_group'] = (df_sales_amount['amount']\n",
+    "                                .apply(lambda x: pct_group(x)))\n",
+    "df_sales_amount.head(10)\n"
    ]
   },
   {
@@ -9478,7 +9499,7 @@
     "# 確認用\n",
     "print('pct25:', pct25)\n",
     "print('pct50:', pct50)\n",
-    "print('pct75:', pct75)"
+    "print('pct75:', pct75)\n"
    ]
   },
   {
@@ -9570,10 +9591,10 @@
    "source": [
     "# コード例2\n",
     "df_temp = df_receipt.groupby('customer_id')[['amount']].sum()\n",
-    "df_temp['quantile'], bins = \\\n",
-    "    pd.qcut(df_receipt.groupby('customer_id')['amount'].sum(), 4, retbins=True)\n",
+    "df_temp['quantile'], bins = pd.qcut(\n",
+    "    df_receipt.groupby('customer_id')['amount'].sum(), 4, retbins=True)\n",
     "display(df_temp.head())\n",
-    "print('quantiles:', bins)"
+    "print('quantiles:', bins)\n"
    ]
   },
   {
@@ -9701,12 +9722,12 @@
    ],
    "source": [
     "# コード例1\n",
-    "df_customer_era = pd.concat([df_customer[['customer_id', 'birth_day']],\n",
-    "                             df_customer['age']. \\\n",
-    "                             apply(lambda x: min(math.floor(x / 10) * 10, 60))],\n",
-    "                             axis=1)\n",
+    "df_customer_era = pd.concat(\n",
+    "    [df_customer[['customer_id', 'birth_day']],\n",
+    "     df_customer['age'].apply(lambda x: min(math.floor(x / 10) * 10, 60))],\n",
+    "    axis=1)\n",
     "\n",
-    "df_customer_era.head(10)"
+    "df_customer_era.head(10)\n"
    ]
   },
   {
@@ -9826,10 +9847,10 @@
    ],
    "source": [
     "# コード例2\n",
-    "df_customer['age_group'] = pd.cut(df_customer['age'], \n",
-    "                                  bins=[0, 10, 20, 30, 40, 50, 60, np.inf], \n",
+    "df_customer['age_group'] = pd.cut(df_customer['age'],\n",
+    "                                  bins=[0, 10, 20, 30, 40, 50, 60, np.inf],\n",
     "                                  right=False)\n",
-    "df_customer[['customer_id', 'birth_day', 'age_group']].head(10)"
+    "df_customer[['customer_id', 'birth_day', 'age_group']].head(10)\n"
    ]
   },
   {
@@ -9967,9 +9988,9 @@
     }
    ],
    "source": [
-    "df_customer_era['era_gender'] = \\\n",
-    "        df_customer['gender_cd'] + df_customer_era['age'].astype('str')\n",
-    "df_customer_era.head(10)"
+    "df_customer_era['era_gender'] = (df_customer['gender_cd']\n",
+    "                                 + df_customer_era['age'].astype('str'))\n",
+    "df_customer_era.head(10)\n"
    ]
   },
   {
@@ -10107,8 +10128,8 @@
     }
    ],
    "source": [
-    "pd.get_dummies(df_customer[['customer_id', 'gender_cd']], \n",
-    "               columns=['gender_cd']).head(10)"
+    "pd.get_dummies(df_customer[['customer_id', 'gender_cd']],\n",
+    "               columns=['gender_cd']).head(10)\n"
    ]
   },
   {
@@ -10244,12 +10265,13 @@
    ],
    "source": [
     "# skleanのpreprocessing.scaleを利用するため、標本標準偏差で計算されている\n",
-    "df_sales_amount = df_receipt.query('not customer_id.str.startswith(\"Z\")', \n",
-    "                                   engine='python'). \\\n",
-    "                                   groupby('customer_id'). \\\n",
-    "                                   agg({'amount':'sum'}).reset_index()\n",
+    "df_sales_amount = (\n",
+    "    df_receipt\n",
+    "    .query('not customer_id.str.startswith(\"Z\")', engine='python')\n",
+    "    .groupby('customer_id').agg({'amount': 'sum'})\n",
+    "    .reset_index())\n",
     "df_sales_amount['amount_ss'] = preprocessing.scale(df_sales_amount['amount'])\n",
-    "df_sales_amount.head(10)"
+    "df_sales_amount.head(10)\n"
    ]
   },
   {
@@ -10369,14 +10391,15 @@
    ],
    "source": [
     "# コード例2（fitを行うことで、別のデータでも同じの平均・標準偏差で標準化を行える）\n",
-    "df_sales_amount = df_receipt.query('not customer_id.str.startswith(\"Z\")', \n",
-    "                                   engine='python'). \\\n",
-    "                                   groupby('customer_id'). \\\n",
-    "                                   agg({'amount':'sum'}).reset_index()\n",
+    "df_sales_amount = (\n",
+    "    df_receipt\n",
+    "    .query('not customer_id.str.startswith(\"Z\")', engine='python')\n",
+    "    .groupby('customer_id').agg({'amount': 'sum'})\n",
+    "    .reset_index())\n",
     "scaler = preprocessing.StandardScaler()\n",
     "scaler.fit(df_sales_amount[['amount']])\n",
     "df_sales_amount['amount_ss'] = scaler.transform(df_sales_amount[['amount']])\n",
-    "df_sales_amount.head(10)"
+    "df_sales_amount.head(10)\n"
    ]
   },
   {
@@ -10504,13 +10527,14 @@
    ],
    "source": [
     "# コード例1\n",
-    "df_sales_amount = df_receipt.query('not customer_id.str.startswith(\"Z\")', \n",
-    "                                   engine='python'). \\\n",
-    "                                   groupby('customer_id'). \\\n",
-    "                                   agg({'amount':'sum'}).reset_index()\n",
+    "df_sales_amount = (\n",
+    "    df_receipt\n",
+    "    .query('not customer_id.str.startswith(\"Z\")', engine='python')\n",
+    "    .groupby('customer_id').agg({'amount': 'sum'})\n",
+    "    .reset_index())\n",
     "df_sales_amount['amount_mm'] = \\\n",
-    "                        preprocessing.minmax_scale(df_sales_amount['amount'])\n",
-    "df_sales_amount.head(10)"
+    "    preprocessing.minmax_scale(df_sales_amount['amount'])\n",
+    "df_sales_amount.head(10)\n"
    ]
   },
   {
@@ -10630,14 +10654,15 @@
    ],
    "source": [
     "# コード例2（fitを行うことで、別のデータでも同じの平均・標準偏差で標準化を行える）\n",
-    "df_sales_amount = df_receipt.query('not customer_id.str.startswith(\"Z\")', \n",
-    "                                   engine='python'). \\\n",
-    "                                   groupby('customer_id'). \\\n",
-    "                                   agg({'amount':'sum'}).reset_index()\n",
+    "df_sales_amount = (\n",
+    "    df_receipt\n",
+    "    .query('not customer_id.str.startswith(\"Z\")', engine='python')\n",
+    "    .groupby('customer_id').agg({'amount': 'sum'})\n",
+    "    .reset_index())\n",
     "scaler = preprocessing.MinMaxScaler()\n",
     "scaler.fit(df_sales_amount[['amount']])\n",
     "df_sales_amount['amount_mm'] = scaler.transform(df_sales_amount[['amount']])\n",
-    "df_sales_amount.head(10)"
+    "df_sales_amount.head(10)\n"
    ]
   },
   {
@@ -10765,12 +10790,13 @@
    ],
    "source": [
     "# skleanのpreprocessing.scaleを利用するため、標本標準偏差で計算されている\n",
-    "df_sales_amount = df_receipt.query('not customer_id.str.startswith(\"Z\")', \n",
-    "                                   engine='python'). \\\n",
-    "                                   groupby('customer_id'). \\\n",
-    "                                   agg({'amount':'sum'}).reset_index()\n",
+    "df_sales_amount = (\n",
+    "    df_receipt\n",
+    "    .query('not customer_id.str.startswith(\"Z\")', engine='python')\n",
+    "    .groupby('customer_id').agg({'amount': 'sum'})\n",
+    "    .reset_index())\n",
     "df_sales_amount['amount_log10'] = np.log10(df_sales_amount['amount'] + 0.5)\n",
-    "df_sales_amount.head(10)"
+    "df_sales_amount.head(10)\n"
    ]
   },
   {
@@ -10897,12 +10923,13 @@
     }
    ],
    "source": [
-    "df_sales_amount = df_receipt.query('not customer_id.str.startswith(\"Z\")', \n",
-    "                                   engine='python'). \\\n",
-    "                                   groupby('customer_id'). \\\n",
-    "                                   agg({'amount':'sum'}).reset_index()\n",
+    "df_sales_amount = (\n",
+    "    df_receipt\n",
+    "    .query('not customer_id.str.startswith(\"Z\")', engine='python')\n",
+    "    .groupby('customer_id').agg({'amount': 'sum'})\n",
+    "    .reset_index())\n",
     "df_sales_amount['amount_loge'] = np.log(df_sales_amount['amount'] + 0.5)\n",
-    "df_sales_amount.head(10)"
+    "df_sales_amount.head(10)\n"
    ]
   },
   {
@@ -11087,7 +11114,7 @@
    "source": [
     "df_tmp = df_product.copy()\n",
     "df_tmp['unit_profit'] = df_tmp['unit_price'] - df_tmp['unit_cost']\n",
-    "df_tmp.head(10)"
+    "df_tmp.head(10)\n"
    ]
   },
   {
@@ -11117,9 +11144,9 @@
    ],
    "source": [
     "df_tmp = df_product.copy()\n",
-    "df_tmp['unit_profit_rate'] = \\\n",
-    "            (df_tmp['unit_price'] - df_tmp['unit_cost']) / df_tmp['unit_price']\n",
-    "df_tmp['unit_profit_rate'].mean(skipna=True)"
+    "df_tmp['unit_profit_rate'] = (\n",
+    "    (df_tmp['unit_price'] - df_tmp['unit_cost']) / df_tmp['unit_price'])\n",
+    "df_tmp['unit_profit_rate'].mean(skipna=True)\n"
    ]
   },
   {
@@ -11315,9 +11342,9 @@
    "source": [
     "df_tmp = df_product.copy()\n",
     "df_tmp['new_price'] = np.floor(df_tmp['unit_cost'] / 0.7)\n",
-    "df_tmp['new_profit_rate'] = \\\n",
-    "            (df_tmp['new_price'] - df_tmp['unit_cost']) / df_tmp['new_price']\n",
-    "df_tmp.head(10)"
+    "df_tmp['new_profit_rate'] = (\n",
+    "    (df_tmp['new_price'] - df_tmp['unit_cost']) / df_tmp['new_price'])\n",
+    "df_tmp.head(10)\n"
    ]
   },
   {
@@ -11513,9 +11540,9 @@
    "source": [
     "df_tmp = df_product.copy()\n",
     "df_tmp['new_price'] = np.round(df_tmp['unit_cost'] / 0.7)\n",
-    "df_tmp['new_profit_rate'] = \\\n",
-    "            (df_tmp['new_price'] - df_tmp['unit_cost']) / df_tmp['new_price']\n",
-    "df_tmp.head(10)"
+    "df_tmp['new_profit_rate'] = (\n",
+    "    (df_tmp['new_price'] - df_tmp['unit_cost']) / df_tmp['new_price'])\n",
+    "df_tmp.head(10)\n"
    ]
   },
   {
@@ -11711,9 +11738,9 @@
    "source": [
     "df_tmp = df_product.copy()\n",
     "df_tmp['new_price'] = np.ceil(df_tmp['unit_cost'] / 0.7)\n",
-    "df_tmp['new_profit_rate'] = \\\n",
-    "            (df_tmp['new_price'] - df_tmp['unit_cost']) / df_tmp['new_price']\n",
-    "df_tmp.head(10)"
+    "df_tmp['new_profit_rate'] = (\n",
+    "    (df_tmp['new_price'] - df_tmp['unit_cost']) / df_tmp['new_price'])\n",
+    "df_tmp.head(10)\n"
    ]
   },
   {
@@ -11898,7 +11925,7 @@
    "source": [
     "df_tmp = df_product.copy()\n",
     "df_tmp['price_tax'] = np.floor(df_tmp['unit_price'] * 1.1)\n",
-    "df_tmp.head(10)"
+    "df_tmp.head(10)\n"
    ]
   },
   {
@@ -12037,17 +12064,19 @@
    ],
    "source": [
     "# コード例1\n",
-    "df_tmp_1 = pd.merge(df_receipt, df_product, \n",
-    "                    how='inner', on='product_cd').groupby('customer_id'). \\\n",
-    "                                            agg({'amount':'sum'}).reset_index()\n",
+    "df_tmp_1 = (pd.merge(df_receipt, df_product,\n",
+    "                     how='inner', on='product_cd')\n",
+    "            .groupby('customer_id').agg({'amount': 'sum'})\n",
+    "            .reset_index())\n",
     "\n",
-    "df_tmp_2 = pd.merge(df_receipt, df_product.query('category_major_cd == \"07\"'), \n",
-    "                    how='inner', on='product_cd').groupby('customer_id').\\\n",
-    "                                            agg({'amount':'sum'}).reset_index()\n",
+    "df_tmp_2 = (pd.merge(df_receipt, df_product.query('category_major_cd == \"07\"'),\n",
+    "                     how='inner', on='product_cd')\n",
+    "            .groupby('customer_id').agg({'amount': 'sum'})\n",
+    "            .reset_index())\n",
     "\n",
     "df_tmp_3 = pd.merge(df_tmp_1, df_tmp_2, how='inner', on='customer_id')\n",
     "df_tmp_3['rate_07'] = df_tmp_3['amount_y'] / df_tmp_3['amount_x']\n",
-    "df_tmp_3.head(10)"
+    "df_tmp_3.head(10)\n"
    ]
   },
   {
@@ -12234,12 +12263,13 @@
    ],
    "source": [
     "# コード例2\n",
-    "df_temp = df_receipt.merge(df_product, how='left', on='product_cd'). \\\n",
-    "        groupby(['customer_id', 'category_major_cd'])['amount'].sum().unstack()\n",
+    "df_temp = (df_receipt.merge(df_product, how='left', on='product_cd')\n",
+    "           .groupby(['customer_id', 'category_major_cd'])['amount'].sum()\n",
+    "           .unstack())\n",
     "df_temp = df_temp[df_temp['07'] > 0]\n",
     "df_temp['sum'] = df_temp.sum(axis=1)\n",
     "df_temp['07_rate'] = df_temp['07'] / df_temp['sum']\n",
-    "df_temp.head(10)"
+    "df_temp.head(10)\n"
    ]
   },
   {
@@ -12377,16 +12407,16 @@
     }
    ],
    "source": [
-    "df_tmp = pd.merge(df_receipt[['customer_id', 'sales_ymd']], \n",
+    "df_tmp = pd.merge(df_receipt[['customer_id', 'sales_ymd']],\n",
     "                  df_customer[['customer_id', 'application_date']],\n",
-    "                 how='inner', on='customer_id')\n",
+    "                  how='inner', on='customer_id')\n",
     "\n",
     "df_tmp = df_tmp.drop_duplicates()\n",
     "\n",
     "df_tmp['sales_ymd'] = pd.to_datetime(df_tmp['sales_ymd'].astype('str'))\n",
     "df_tmp['application_date'] = pd.to_datetime(df_tmp['application_date'])\n",
     "df_tmp['elapsed_date'] = df_tmp['sales_ymd'] - df_tmp['application_date']\n",
-    "df_tmp.head(10)"
+    "df_tmp.head(10)\n"
    ]
   },
   {
@@ -12524,20 +12554,21 @@
     }
    ],
    "source": [
-    "df_tmp = pd.merge(df_receipt[['customer_id', 'sales_ymd']], \n",
+    "df_tmp = pd.merge(df_receipt[['customer_id', 'sales_ymd']],\n",
     "                  df_customer[['customer_id', 'application_date']],\n",
-    "                 how='inner', on='customer_id')\n",
+    "                  how='inner', on='customer_id')\n",
     "\n",
     "df_tmp = df_tmp.drop_duplicates()\n",
     "\n",
     "df_tmp['sales_ymd'] = pd.to_datetime(df_tmp['sales_ymd'].astype('str'))\n",
     "df_tmp['application_date'] = pd.to_datetime(df_tmp['application_date'])\n",
     "\n",
-    "df_tmp['elapsed_date'] = df_tmp[['sales_ymd', 'application_date']]. \\\n",
-    "    apply(lambda x: relativedelta(x[0], x[1]).years * 12 + \\\n",
-    "                    relativedelta(x[0], x[1]).months, axis=1)\n",
+    "df_tmp['elapsed_date'] = (\n",
+    "    df_tmp[['sales_ymd', 'application_date']]\n",
+    "    .apply(lambda x: relativedelta(x[0], x[1]).years * 12\n",
+    "           + relativedelta(x[0], x[1]).months, axis=1))\n",
     "\n",
-    "df_tmp.sort_values('customer_id').head(10)"
+    "df_tmp.sort_values('customer_id').head(10)\n"
    ]
   },
   {
@@ -12675,7 +12706,7 @@
     }
    ],
    "source": [
-    "df_tmp = pd.merge(df_receipt[['customer_id', 'sales_ymd']], \n",
+    "df_tmp = pd.merge(df_receipt[['customer_id', 'sales_ymd']],\n",
     "                  df_customer[['customer_id', 'application_date']],\n",
     "                  how='inner', on='customer_id')\n",
     "\n",
@@ -12684,9 +12715,10 @@
     "df_tmp['sales_ymd'] = pd.to_datetime(df_tmp['sales_ymd'].astype('str'))\n",
     "df_tmp['application_date'] = pd.to_datetime(df_tmp['application_date'])\n",
     "\n",
-    "df_tmp['elapsed_date'] = df_tmp[['sales_ymd', 'application_date']]. \\\n",
-    "                    apply(lambda x: relativedelta(x[0], x[1]).years, axis=1)\n",
-    "df_tmp.head(10)"
+    "df_tmp['elapsed_date'] = (\n",
+    "    df_tmp[['sales_ymd', 'application_date']]\n",
+    "    .apply(lambda x: relativedelta(x[0], x[1]).years, axis=1))\n",
+    "df_tmp.head(10)\n"
    ]
   },
   {
@@ -12824,7 +12856,7 @@
     }
    ],
    "source": [
-    "df_tmp = pd.merge(df_receipt[['customer_id', 'sales_ymd']], \n",
+    "df_tmp = pd.merge(df_receipt[['customer_id', 'sales_ymd']],\n",
     "                  df_customer[['customer_id', 'application_date']],\n",
     "                  how='inner', on='customer_id')\n",
     "\n",
@@ -12833,10 +12865,10 @@
     "df_tmp['sales_ymd'] = pd.to_datetime(df_tmp['sales_ymd'].astype('str'))\n",
     "df_tmp['application_date'] = pd.to_datetime(df_tmp['application_date'])\n",
     "\n",
-    "df_tmp['elapsed_date'] = \\\n",
-    "    (df_tmp['sales_ymd'].view(np.int64) / 10**9) - (df_tmp['application_date'].\\\n",
-    "                                                    view(np.int64) / 10**9)\n",
-    "df_tmp.head(10)"
+    "df_tmp['elapsed_date'] = (\n",
+    "    (df_tmp['sales_ymd'].view(np.int64) / 10**9)\n",
+    "    - (df_tmp['application_date'].view(np.int64) / 10**9))\n",
+    "df_tmp.head(10)\n"
    ]
   },
   {
@@ -12977,10 +13009,11 @@
     "df_tmp = df_receipt[['customer_id', 'sales_ymd']]\n",
     "df_tmp = df_tmp.drop_duplicates()\n",
     "df_tmp['sales_ymd'] = pd.to_datetime(df_tmp['sales_ymd'].astype('str'))\n",
-    "df_tmp['monday'] = df_tmp['sales_ymd']. \\\n",
-    "                        apply(lambda x: x - relativedelta(days=x.weekday()))\n",
+    "df_tmp['monday'] = (\n",
+    "    df_tmp['sales_ymd']\n",
+    "    .apply(lambda x: x - relativedelta(days=x.weekday())))\n",
     "df_tmp['elapsed_weekday'] = df_tmp['sales_ymd'] - df_tmp['monday']\n",
-    "df_tmp.head(10)"
+    "df_tmp.head(10)\n"
    ]
   },
   {
@@ -13306,9 +13339,9 @@
    ],
    "source": [
     "# sklearn.model_selection.train_test_splitを使用した例\n",
-    "_, df_tmp = train_test_split(df_customer, test_size=0.1, \n",
+    "_, df_tmp = train_test_split(df_customer, test_size=0.1,\n",
     "                             stratify=df_customer['gender_cd'])\n",
-    "df_tmp.groupby('gender_cd').agg({'customer_id' : 'count'})"
+    "df_tmp.groupby('gender_cd').agg({'customer_id': 'count'})\n"
    ]
   },
   {
@@ -13678,12 +13711,14 @@
    ],
    "source": [
     "# skleanのpreprocessing.scaleを利用するため、標本標準偏差で計算されている\n",
-    "df_sales_amount = df_receipt.query('not customer_id.str.startswith(\"Z\")', \n",
-    "                                   engine='python'). \\\n",
-    "                                   groupby('customer_id'). \\\n",
-    "                                   agg({'amount':'sum'}).reset_index()\n",
+    "df_sales_amount = (\n",
+    "    df_receipt\n",
+    "    .query('not customer_id.str.startswith(\"Z\")', engine='python')\n",
+    "    .groupby('customer_id').agg({'amount': 'sum'})\n",
+    "    .reset_index())\n",
+    "\n",
     "df_sales_amount['amount_ss'] = preprocessing.scale(df_sales_amount['amount'])\n",
-    "df_sales_amount.query('abs(amount_ss) >= 3').head(10)"
+    "df_sales_amount.query('abs(amount_ss) >= 3').head(10)\n"
    ]
   },
   {
@@ -13799,17 +13834,19 @@
     }
    ],
    "source": [
-    "df_sales_amount = df_receipt.query('not customer_id.str.startswith(\"Z\")', \n",
-    "                                   engine='python'). \\\n",
-    "                                   groupby('customer_id'). \\\n",
-    "                                   agg({'amount':'sum'}).reset_index()\n",
+    "df_sales_amount = (\n",
+    "    df_receipt\n",
+    "    .query('not customer_id.str.startswith(\"Z\")', engine='python')\n",
+    "    .groupby('customer_id').agg({'amount': 'sum'})\n",
+    "    .reset_index())\n",
     "\n",
     "pct75 = np.percentile(df_sales_amount['amount'], q=75)\n",
     "pct25 = np.percentile(df_sales_amount['amount'], q=25)\n",
     "iqr = pct75 - pct25\n",
     "amount_low = pct25 - (iqr * 1.5)\n",
     "amount_hight = pct75 + (iqr * 1.5)\n",
-    "df_sales_amount.query('amount < @amount_low or @amount_hight < amount').head(10)"
+    "df_sales_amount.query(\n",
+    "    'amount < @amount_low or @amount_hight < amount').head(10)\n"
    ]
   },
   {
@@ -13872,7 +13909,7 @@
     "df_product_1 = df_product.copy()\n",
     "print('削除前:', len(df_product_1))\n",
     "df_product_1.dropna(inplace=True)\n",
-    "print('削除後:', len(df_product_1))"
+    "print('削除後:', len(df_product_1))\n"
    ]
   },
   {
@@ -13907,10 +13944,10 @@
    ],
    "source": [
     "\n",
-    "df_product_2 = df_product.fillna({\n",
-    "    'unit_price':np.round(np.nanmean(df_product['unit_price'])), \n",
-    "    'unit_cost':np.round(np.nanmean(df_product['unit_cost']))})\n",
-    "df_product_2.isnull().sum()"
+    "df_product_2 = df_product.fillna(\n",
+    "    {'unit_price': np.round(np.nanmean(df_product['unit_price'])),\n",
+    "     'unit_cost': np.round(np.nanmean(df_product['unit_cost']))})\n",
+    "df_product_2.isnull().sum()\n"
    ]
   },
   {
@@ -13944,10 +13981,10 @@
     }
    ],
    "source": [
-    "df_product_3 = df_product.fillna({\n",
-    "    'unit_price':np.round(np.nanmedian(df_product['unit_price'])), \n",
-    "    'unit_cost':np.round(np.nanmedian(df_product['unit_cost']))})\n",
-    "df_product_3.isnull().sum()"
+    "df_product_3 = df_product.fillna(\n",
+    "    {'unit_price': np.round(np.nanmedian(df_product['unit_price'])),\n",
+    "     'unit_cost': np.round(np.nanmedian(df_product['unit_cost']))})\n",
+    "df_product_3.isnull().sum()\n"
    ]
   },
   {
@@ -13984,18 +14021,23 @@
    ],
    "source": [
     "# コード例1\n",
-    "df_tmp = df_product.groupby('category_small_cd'). \\\n",
-    "                agg({'unit_price':'median', 'unit_cost':'median'}).reset_index()\n",
+    "df_tmp = (df_product\n",
+    "          .groupby('category_small_cd')\n",
+    "          .agg({'unit_price': 'median', 'unit_cost': 'median'})\n",
+    "          .reset_index())\n",
     "df_tmp.columns = ['category_small_cd', 'median_price', 'median_cost']\n",
     "\n",
-    "df_product_4 = pd.merge(df_product, df_tmp, how='inner', on='category_small_cd')\n",
+    "df_product_4 = pd.merge(df_product, df_tmp, how='inner',\n",
+    "                        on='category_small_cd')\n",
     "\n",
-    "df_product_4['unit_price'] = df_product_4[['unit_price', 'median_price']]. \\\n",
-    "            apply(lambda x: np.round(x[1]) if np.isnan(x[0]) else x[0], axis=1)\n",
-    "df_product_4['unit_cost'] = df_product_4[['unit_cost', 'median_cost']]. \\\n",
-    "            apply(lambda x: np.round(x[1]) if np.isnan(x[0]) else x[0], axis=1)\n",
+    "df_product_4['unit_price'] = (\n",
+    "    df_product_4[['unit_price', 'median_price']]\n",
+    "    .apply(lambda x: np.round(x[1]) if np.isnan(x[0]) else x[0], axis=1))\n",
+    "df_product_4['unit_cost'] = (\n",
+    "    df_product_4[['unit_cost', 'median_cost']]\n",
+    "    .apply(lambda x: np.round(x[1]) if np.isnan(x[0]) else x[0], axis=1))\n",
     "\n",
-    "df_product_4.isnull().sum()"
+    "df_product_4.isnull().sum()\n"
    ]
   },
   {
@@ -14026,22 +14068,22 @@
     "# コード例2（maskの活用）\n",
     "df_tmp = (df_product\n",
     "          .groupby('category_small_cd')\n",
-    "          .agg(median_price=('unit_price', 'median'), \n",
+    "          .agg(median_price=('unit_price', 'median'),\n",
     "               median_cost=('unit_cost', 'median'))\n",
     "          .reset_index())\n",
     "\n",
-    "df_product_4 = df_product.merge(df_tmp, \n",
-    "                                how='inner', \n",
+    "df_product_4 = df_product.merge(df_tmp,\n",
+    "                                how='inner',\n",
     "                                on='category_small_cd')\n",
     "\n",
     "df_product_4['unit_price'] = (df_product_4['unit_price']\n",
-    "                              .mask(df_product_4['unit_price'].isnull(), \n",
+    "                              .mask(df_product_4['unit_price'].isnull(),\n",
     "                                    df_product_4['median_price'].round()))\n",
     "df_product_4['unit_cost'] = (df_product_4['unit_cost']\n",
-    "                              .mask(df_product_4['unit_cost'].isnull(), \n",
-    "                                    df_product_4['median_cost'].round()))\n",
+    "                             .mask(df_product_4['unit_cost'].isnull(),\n",
+    "                                   df_product_4['median_cost'].round()))\n",
     "\n",
-    "df_product_4.isnull().sum()"
+    "df_product_4.isnull().sum()\n"
    ]
   },
   {
@@ -14070,13 +14112,12 @@
     "# コード例3（fillna、transformの活用）\n",
     "df_product_4 = df_product.copy()\n",
     "\n",
-    "for x in ['unit_price', 'unit_cost']: \n",
+    "for x in ['unit_price', 'unit_cost']:\n",
     "    df_product_4[x] = (df_product_4[x]\n",
     "                       .fillna(df_product_4.groupby('category_small_cd')[x]\n",
-    "                               .transform('median')\n",
-    "                               .round()))\n",
+    "                               .transform('median').round()))\n",
     "\n",
-    "df_product_4.isnull().sum()"
+    "df_product_4.isnull().sum()\n"
    ]
   },
   {
@@ -14094,23 +14135,23 @@
    "outputs": [],
    "source": [
     "df_tmp_1 = df_receipt.query('20190101 <= sales_ymd <= 20191231')\n",
-    "df_tmp_1 = pd.merge(df_customer['customer_id'], \n",
-    "                    df_tmp_1[['customer_id', 'amount']], \n",
-    "                    how='left', on='customer_id'). \\\n",
-    "                    groupby('customer_id').sum().reset_index(). \\\n",
-    "                    rename(columns={'amount':'amount_2019'})\n",
+    "df_tmp_1 = (pd.merge(df_customer['customer_id'],\n",
+    "                     df_tmp_1[['customer_id', 'amount']],\n",
+    "                     how='left', on='customer_id')\n",
+    "            .groupby('customer_id').sum().reset_index()\n",
+    "            .rename(columns={'amount': 'amount_2019'}))\n",
     "\n",
-    "df_tmp_2 = pd.merge(df_customer['customer_id'], \n",
-    "                    df_receipt[['customer_id', 'amount']], \n",
-    "                    how='left', on='customer_id'). \\\n",
-    "                    groupby('customer_id').sum().reset_index()\n",
+    "df_tmp_2 = (pd.merge(df_customer['customer_id'],\n",
+    "                     df_receipt[['customer_id', 'amount']],\n",
+    "                     how='left', on='customer_id')\n",
+    "            .groupby('customer_id').sum().reset_index())\n",
     "\n",
     "df_tmp = pd.merge(df_tmp_1, df_tmp_2, how='inner', on='customer_id')\n",
     "df_tmp['amount_2019'] = df_tmp['amount_2019'].fillna(0)\n",
     "df_tmp['amount'] = df_tmp['amount'].fillna(0)\n",
     "\n",
     "df_tmp['amount_rate'] = df_tmp['amount_2019'] / df_tmp['amount']\n",
-    "df_tmp['amount_rate'] = df_tmp['amount_rate'].fillna(0)"
+    "df_tmp['amount_rate'] = df_tmp['amount_rate'].fillna(0)\n"
    ]
   },
   {
@@ -14397,15 +14438,18 @@
    ],
    "source": [
     "df_customer_1 = pd.merge(df_customer[['customer_id', 'postal_cd']],\n",
-    "                         df_geocode[['postal_cd', 'longitude' ,'latitude']],\n",
+    "                         df_geocode[['postal_cd', 'longitude', 'latitude']],\n",
     "                         how='inner', on='postal_cd')\n",
-    "df_customer_1 = df_customer_1.groupby('customer_id'). \\\n",
-    "    agg({'longitude':'mean', 'latitude':'mean'}).reset_index(). \\\n",
-    "    rename(columns={'longitude':'m_longitude', 'latitude':'m_latitude'})\n",
+    "df_customer_1 = (df_customer_1\n",
+    "                 .groupby('customer_id').agg({'longitude': 'mean',\n",
+    "                                              'latitude': 'mean'})\n",
+    "                 .reset_index()\n",
+    "                 .rename(columns={'longitude': 'm_longitude',\n",
+    "                                  'latitude': 'm_latitude'}))\n",
     "\n",
-    "df_customer_1 = pd.merge(df_customer, df_customer_1, \n",
+    "df_customer_1 = pd.merge(df_customer, df_customer_1,\n",
     "                         how='inner', on='customer_id')\n",
-    "df_customer_1.head(3)"
+    "df_customer_1.head(3)\n"
    ]
   },
   {
@@ -14557,19 +14601,22 @@
    "source": [
     "# コード例1\n",
     "def calc_distance(x1, y1, x2, y2):\n",
-    "    distance = 6371 * math.acos(math.sin(math.radians(y1)) \n",
-    "                    * math.sin(math.radians(y2)) \n",
-    "                    + math.cos(math.radians(y1)) \n",
-    "                    * math.cos(math.radians(y2)) \n",
-    "                    * math.cos(math.radians(x1) - math.radians(x2)))\n",
+    "    distance = 6371 * math.acos(math.sin(math.radians(y1))\n",
+    "                                * math.sin(math.radians(y2))\n",
+    "                                + math.cos(math.radians(y1))\n",
+    "                                * math.cos(math.radians(y2))\n",
+    "                                * math.cos(math.radians(x1) - math.radians(x2)))\n",
     "    return distance\n",
     "\n",
-    "df_tmp = pd.merge(df_customer_1, df_store, how='inner', left_on='application_store_cd', right_on='store_cd')    \n",
     "\n",
-    "df_tmp['distance'] =   df_tmp[['m_longitude', 'm_latitude','longitude', 'latitude']]. \\\n",
-    "                                apply(lambda x: calc_distance(x[0], x[1], x[2], x[3]), axis=1)\n",
+    "df_tmp = pd.merge(df_customer_1, df_store, how='inner',\n",
+    "                  left_on='application_store_cd', right_on='store_cd')\n",
     "\n",
-    "df_tmp[['customer_id', 'address_x', 'address_y', 'distance']].head(10)"
+    "df_tmp['distance'] = (\n",
+    "    df_tmp[['m_longitude', 'm_latitude', 'longitude', 'latitude']]\n",
+    "    .apply(lambda x: calc_distance(x[0], x[1], x[2], x[3]), axis=1))\n",
+    "\n",
+    "df_tmp[['customer_id', 'address_x', 'address_y', 'distance']].head(10)\n"
    ]
   },
   {
@@ -14705,21 +14752,22 @@
     "    x2_r = np.radians(x2)\n",
     "    y1_r = np.radians(y1)\n",
     "    y2_r = np.radians(y2)\n",
-    "    return 6371 * np.arccos(np.sin(y1_r) * np.sin(y2_r) \n",
-    "                            + np.cos(y1_r) * np.cos(y2_r) \n",
+    "    return 6371 * np.arccos(np.sin(y1_r) * np.sin(y2_r)\n",
+    "                            + np.cos(y1_r) * np.cos(y2_r)\n",
     "                            * np.cos(x1_r - x2_r))\n",
     "\n",
-    "df_tmp = df_customer_1.merge(df_store, \n",
-    "                             how='inner', \n",
-    "                             left_on='application_store_cd', \n",
-    "                             right_on='store_cd')    \n",
     "\n",
-    "df_tmp['distance'] =   calc_distance_numpy(df_tmp['m_longitude'], \n",
-    "                                           df_tmp['m_latitude'],\n",
-    "                                           df_tmp['longitude'], \n",
-    "                                           df_tmp['latitude'])\n",
+    "df_tmp = df_customer_1.merge(df_store,\n",
+    "                             how='inner',\n",
+    "                             left_on='application_store_cd',\n",
+    "                             right_on='store_cd')\n",
     "\n",
-    "df_tmp[['customer_id', 'address_x', 'address_y', 'distance']].head(10)"
+    "df_tmp['distance'] = calc_distance_numpy(df_tmp['m_longitude'],\n",
+    "                                         df_tmp['m_latitude'],\n",
+    "                                         df_tmp['longitude'],\n",
+    "                                         df_tmp['latitude'])\n",
+    "\n",
+    "df_tmp[['customer_id', 'address_x', 'address_y', 'distance']].head(10)\n"
    ]
   },
   {
@@ -14744,25 +14792,25 @@
     }
    ],
    "source": [
-    "df_receipt_tmp = df_receipt.groupby('customer_id') \\\n",
-    "                    .agg(sum_amount=('amount','sum')).reset_index()\n",
+    "df_receipt_tmp = (df_receipt.groupby('customer_id')\n",
+    "                  .agg(sum_amount=('amount', 'sum'))\n",
+    "                  .reset_index())\n",
     "\n",
-    "df_customer_u = pd.merge(df_customer, df_receipt_tmp, \n",
-    "                         how='left', \n",
+    "df_customer_u = pd.merge(df_customer, df_receipt_tmp,\n",
+    "                         how='left',\n",
     "                         on='customer_id')\n",
     "\n",
     "df_customer_u['sum_amount'] = df_customer_u['sum_amount'].fillna(0)\n",
     "\n",
-    "df_customer_u = df_customer_u.sort_values(['sum_amount', 'customer_id'], \n",
+    "df_customer_u = df_customer_u.sort_values(['sum_amount', 'customer_id'],\n",
     "                                          ascending=[False, True])\n",
     "\n",
-    "df_customer_u.drop_duplicates(subset=['customer_name', 'postal_cd'], \n",
+    "df_customer_u.drop_duplicates(subset=['customer_name', 'postal_cd'],\n",
     "                              keep='first', inplace=True)\n",
     "\n",
     "print('df_customer:', len(df_customer),\n",
     "      'df_customer_u:', len(df_customer_u),\n",
-    "      'diff:', len(df_customer) - len(df_customer_u))\n",
-    "\n"
+    "      'diff:', len(df_customer) - len(df_customer_u))\n"
    ]
   },
   {
@@ -14790,15 +14838,16 @@
     }
    ],
    "source": [
-    "df_customer_n = pd.merge(df_customer, \n",
-    "                         df_customer_u[['customer_name', \n",
-    "                                        'postal_cd', 'customer_id']],\n",
-    "                         how='inner', on =['customer_name', 'postal_cd'])\n",
-    "df_customer_n.rename(columns={'customer_id_x':'customer_id', \n",
-    "                              'customer_id_y':'integration_id'}, inplace=True)\n",
+    "df_customer_n = pd.merge(\n",
+    "    df_customer,\n",
+    "    df_customer_u[['customer_name', 'postal_cd', 'customer_id']],\n",
+    "    how='inner', on=['customer_name', 'postal_cd'])\n",
+    "df_customer_n.rename(columns={'customer_id_x': 'customer_id',\n",
+    "                              'customer_id_y': 'integration_id'}, inplace=True)\n",
     "\n",
-    "print('ID数の差', len(df_customer_n['customer_id'].unique()) \n",
-    "                         - len(df_customer_n['integration_id'].unique()))"
+    "print('ID数の差',\n",
+    "      len(df_customer_n['customer_id'].unique())\n",
+    "      - len(df_customer_n['integration_id'].unique()))\n"
    ]
   },
   {
@@ -14842,12 +14891,12 @@
     }
    ],
    "source": [
-    "df_sales= df_receipt.groupby('customer_id').agg({'amount':sum}).reset_index()\n",
-    "df_tmp = pd.merge(df_customer, df_sales['customer_id'], \n",
+    "df_sales = df_receipt.groupby('customer_id').agg({'amount': sum}).reset_index()\n",
+    "df_tmp = pd.merge(df_customer, df_sales['customer_id'],\n",
     "                  how='inner', on='customer_id')\n",
     "df_train, df_test = train_test_split(df_tmp, test_size=0.2, random_state=71)\n",
     "print('学習データ割合: ', len(df_train) / len(df_tmp))\n",
-    "print('テストデータ割合: ', len(df_test) / len(df_tmp))"
+    "print('テストデータ割合: ', len(df_test) / len(df_tmp))\n"
    ]
   },
   {
@@ -14866,20 +14915,21 @@
    "source": [
     "df_tmp = df_receipt[['sales_ymd', 'amount']].copy()\n",
     "df_tmp['sales_ym'] = df_tmp['sales_ymd'].astype('str').str[0:6]\n",
-    "df_tmp = df_tmp.groupby('sales_ym').agg({'amount':'sum'}).reset_index()\n",
+    "df_tmp = df_tmp.groupby('sales_ym').agg({'amount': 'sum'}).reset_index()\n",
     "\n",
     "# 関数化することで長期間データに対する多数のデータセットもループなどで処理できるようにする\n",
     "def split_data(df, train_size, test_size, slide_window, start_point):\n",
     "    train_start = start_point * slide_window\n",
     "    test_start = train_start + train_size\n",
-    "    return df[train_start : test_start], df[test_start : test_start + test_size]\n",
+    "    return df[train_start: test_start], df[test_start: test_start + test_size]\n",
     "\n",
-    "df_train_1, df_test_1 = split_data(df_tmp, train_size=12, \n",
+    "\n",
+    "df_train_1, df_test_1 = split_data(df_tmp, train_size=12,\n",
     "                                   test_size=6, slide_window=6, start_point=0)\n",
-    "df_train_2, df_test_2 = split_data(df_tmp, train_size=12, \n",
+    "df_train_2, df_test_2 = split_data(df_tmp, train_size=12,\n",
     "                                   test_size=6, slide_window=6, start_point=1)\n",
-    "df_train_3, df_test_3 = split_data(df_tmp, train_size=12, \n",
-    "                                   test_size=6, slide_window=6, start_point=2)"
+    "df_train_3, df_test_3 = split_data(df_tmp, train_size=12,\n",
+    "                                   test_size=6, slide_window=6, start_point=2)\n"
    ]
   },
   {
@@ -15112,8 +15162,8 @@
    ],
    "source": [
     "# コード例1\n",
-    "#unbalancedのubUnderを使った例\n",
-    "df_tmp = df_receipt.groupby('customer_id').agg({'amount':'sum'}).reset_index()\n",
+    "# unbalancedのubUnderを使った例\n",
+    "df_tmp = df_receipt.groupby('customer_id').agg({'amount': 'sum'}).reset_index()\n",
     "df_tmp = pd.merge(df_customer, df_tmp, how='left', on='customer_id')\n",
     "df_tmp['buy_flg'] = df_tmp['amount'].apply(lambda x: 0 if np.isnan(x) else 1)\n",
     "\n",
@@ -15127,7 +15177,7 @@
     "df_sample, _ = rs.fit_resample(df_tmp, df_tmp.buy_flg)\n",
     "\n",
     "print('0の件数', len(df_sample.query('buy_flg == 0')))\n",
-    "print('1の件数', len(df_sample.query('buy_flg == 1')))"
+    "print('1の件数', len(df_sample.query('buy_flg == 1')))\n"
    ]
   },
   {
@@ -15153,25 +15203,24 @@
    ],
    "source": [
     "# コード例2\n",
-    "#unbalancedのubUnderを使った例\n",
-    "df_tmp = df_customer.merge(df_receipt\n",
-    "                           .groupby('customer_id')['amount'].sum()\n",
-    "                           .reset_index(), \n",
-    "                           how='left', \n",
-    "                           on='customer_id')\n",
+    "# unbalancedのubUnderを使った例\n",
+    "df_tmp = pd.merge(\n",
+    "    df_customer,\n",
+    "    df_receipt.groupby('customer_id')['amount'].sum().reset_index(),\n",
+    "    how='left', on='customer_id')\n",
     "df_tmp['buy_flg'] = np.where(df_tmp['amount'].isnull(), 0, 1)\n",
     "\n",
-    "print(\"サンプリング前のbuy_flgの件数\")\n",
-    "print(df_tmp['buy_flg'].value_counts(), \"\\n\")\n",
+    "print('サンプリング前のbuy_flgの件数')\n",
+    "print(df_tmp['buy_flg'].value_counts(), '\\n')\n",
     "\n",
     "positive_count = (df_tmp['buy_flg'] == 1).sum()\n",
     "\n",
     "rs = RandomUnderSampler(random_state=71)\n",
     "\n",
-    "df_sample, _ = rs.fit_resample(df_tmp, df_tmp.buy_flg)\n",
+    "df_sample, _ = rs.fit_resample(df_tmp, df_tmp['buy_flg'])\n",
     "\n",
-    "print(\"サンプリング後のbuy_flgの件数\")\n",
-    "print(df_sample['buy_flg'].value_counts())"
+    "print('サンプリング後のbuy_flgの件数')\n",
+    "print(df_sample['buy_flg'].value_counts())\n"
    ]
   },
   {
@@ -15189,7 +15238,7 @@
    "outputs": [],
    "source": [
     "df_gender = df_customer[['gender_cd', 'gender']].drop_duplicates()\n",
-    "df_customer_s = df_customer.drop(columns='gender')"
+    "df_customer_s = df_customer.drop(columns='gender')\n"
    ]
   },
   {
@@ -15207,11 +15256,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_product_full = pd.merge(df_product, df_category[['category_small_cd', \n",
-    "                                                    'category_major_name',\n",
-    "                                                    'category_medium_name',\n",
-    "                                                    'category_small_name']], \n",
-    "                           how = 'inner', on = 'category_small_cd')"
+    "df_product_full = pd.merge(\n",
+    "    df_product,\n",
+    "    df_category[['category_small_cd',\n",
+    "                 'category_major_name',\n",
+    "                 'category_medium_name',\n",
+    "                 'category_small_name']],\n",
+    "    how='inner', on='category_small_cd')\n"
    ]
   },
   {
@@ -15233,8 +15284,8 @@
    "outputs": [],
    "source": [
     "# コード例1\n",
-    "df_product_full.to_csv('../data/P_df_product_full_UTF-8_header.csv', \n",
-    "                       encoding='UTF-8', index=False)"
+    "df_product_full.to_csv('../data/P_df_product_full_UTF-8_header.csv',\n",
+    "                       encoding='UTF-8', index=False)\n"
    ]
   },
   {
@@ -15244,8 +15295,8 @@
    "outputs": [],
    "source": [
     "# コード例2（BOM付きでExcelの文字化けを防ぐ）\n",
-    "df_product_full.to_csv('../data/P_df_product_full_UTF-8_header.csv', \n",
-    "                       encoding='utf_8_sig', index=False)"
+    "df_product_full.to_csv('../data/P_df_product_full_UTF-8_header.csv',\n",
+    "                       encoding='utf_8_sig', index=False)\n"
    ]
   },
   {
@@ -15266,8 +15317,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_product_full.to_csv('../data/P_df_product_full_CP932_header.csv', \n",
-    "                       encoding='CP932', index=False)"
+    "df_product_full.to_csv('../data/P_df_product_full_CP932_header.csv',\n",
+    "                       encoding='CP932', index=False)\n"
    ]
   },
   {
@@ -15288,8 +15339,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_product_full.to_csv('../data/P_df_product_full_UTF-8_noh.csv', \n",
-    "                       header=False ,encoding='UTF-8', index=False)"
+    "df_product_full.to_csv('../data/P_df_product_full_UTF-8_noh.csv',\n",
+    "                       header=False, encoding='UTF-8', index=False)\n"
    ]
   },
   {
@@ -15406,11 +15457,11 @@
    ],
    "source": [
     "df_tmp = pd.read_csv('../data/P_df_product_full_UTF-8_header.csv',\n",
-    "                     dtype={'category_major_cd':str,\n",
-    "                            'category_medium_cd':str,\n",
-    "                            'category_small_cd':str},\n",
+    "                     dtype={'category_major_cd': str,\n",
+    "                            'category_medium_cd': str,\n",
+    "                            'category_small_cd': str},\n",
     "                     encoding='UTF-8')\n",
-    "df_tmp.head(3)"
+    "df_tmp.head(3)\n"
    ]
   },
   {
@@ -15517,11 +15568,11 @@
    ],
    "source": [
     "df_tmp = pd.read_csv('../data/P_df_product_full_UTF-8_noh.csv',\n",
-    "                     dtype={1:str,\n",
-    "                            2:str,\n",
-    "                            3:str},\n",
+    "                     dtype={1: str,\n",
+    "                            2: str,\n",
+    "                            3: str},\n",
     "                     encoding='UTF-8', header=None)\n",
-    "df_tmp.head(3)"
+    "df_tmp.head(3)\n"
    ]
   },
   {
@@ -15542,8 +15593,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_product_full.to_csv('../data/P_df_product_full_UTF-8_header.tsv', \n",
-    "                       sep='\\t', encoding='UTF-8', index=False)"
+    "df_product_full.to_csv('../data/P_df_product_full_UTF-8_header.tsv',\n",
+    "                       sep='\\t', encoding='UTF-8', index=False)\n"
    ]
   },
   {
@@ -15659,12 +15710,12 @@
     }
    ],
    "source": [
-    "df_tmp = pd.read_table('../data/P_df_product_full_UTF-8_header.tsv', \n",
-    "                       dtype={'category_major_cd':str,\n",
-    "                              'category_medium_cd':str,\n",
-    "                              'category_small_cd':str},\n",
+    "df_tmp = pd.read_table('../data/P_df_product_full_UTF-8_header.tsv',\n",
+    "                       dtype={'category_major_cd': str,\n",
+    "                              'category_medium_cd': str,\n",
+    "                              'category_small_cd': str},\n",
     "                       encoding='UTF-8')\n",
-    "df_tmp.head(3)"
+    "df_tmp.head(3)\n"
    ]
   },
   {


### PR DESCRIPTION
- 不自然・不統一なインデント幅・半角スペースの位置などの修正（主にPEP8に基づく）
- 不自然・不統一な改行位置の変更と長すぎる行の改行、なるべく以下のローカルルールに基づく：
    - 演算子の直後で改行しない（これはPEP8に基づく）
    - 代入操作では`\`を用いた改行を行わず、範囲をわかりやすくするため`()`で括った改行を行う
    - 類似問題・類似コードが連続する場合には、互いに改行位置を統一する
- 文字列型の引用符に`""`を使用している箇所は`''`に統一
- データフレームからシリーズ（列）を取得する際に`.`（属性アクセス）を使用している箇所は`[]`を使用した取得に統一
- 最初のセルの`import datetime`は使用していないので削除
- `Series.str.contains()`において`regex=True`はデフォルト動作であり記述不要のため削除、代わりにパターンをraw文字列記法にし正規表現が用いられていることをユーザーに暗示
