### PR TITLE
postgresイメージをbullseyeベースに変更する

### DIFF
--- a/dockerfiles/postgres/Dockerfile
+++ b/dockerfiles/postgres/Dockerfile
@@ -1,2 +1,2 @@
-FROM postgres:14.1-alpine
+FROM postgres:14.1-bullseye
 ENV LANG ja_JP.utf8

--- a/dockerfiles/postgres/Dockerfile
+++ b/dockerfiles/postgres/Dockerfile
@@ -1,2 +1,5 @@
 FROM postgres:14.1-bullseye
+
+RUN sed -i -E 's/# (ja_JP.UTF-8)/\1/' /etc/locale.gen \
+    && locale-gen
 ENV LANG ja_JP.utf8


### PR DESCRIPTION
https://blog.inductor.me/entry/alpine-not-recommended

alpineを使うのはライブラリの面であまり良くないという話があるので、build時のDockerイメージをbullseyeベースにします。