### PR TITLE
apt-get関連の命令削除

### DIFF
--- a/dockerfiles/notebook/Dockerfile
+++ b/dockerfiles/notebook/Dockerfile
@@ -1,20 +1,9 @@
 FROM jupyter/datascience-notebook:python-3.9.6
 #FROM jupyter/datascience-notebook:d53a302fbcd0
 USER root
-ENV DEBCONF_NOWARNINGS yes
 
 # mambaでR依存パッケージをインストール
 RUN mamba install --quiet --yes r-themis==0.1.4 r-rpostgresql==0.6_2
-
-# 最新のpostgresqlへの対応を行っている (参考: https://www.postgresql.org/download/linux/ubuntu/ )
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends lsb-release gnupg \
-    && sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' \
-    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-    && apt-get remove -y lsb-release gnupg \
-    && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/*
 
 USER jovyan
 WORKDIR /home/jovyan


### PR DESCRIPTION
https://github.com/The-Japan-DataScientist-Society/100knocks-preprocess/pull/145 により `apt-get` でパッケージをインストールする必要がなくなったので、 `apt-get` 関連の命令を削除します。