### PR TITLE
docker compose v2対応

### DIFF
--- a/.github/workflows/run_notebooks.yml
+++ b/.github/workflows/run_notebooks.yml
@@ -17,12 +17,12 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
           COMPOSE_DOCKER_CLI_BUILD: 1
-        run: docker-compose build --no-cache
+        run: docker compose build --no-cache
       - name: Run docker containers
         env:
           DOCKER_BUILDKIT: 1
           COMPOSE_DOCKER_CLI_BUILD: 1
-        run: docker-compose up -d
+        run: docker compose up -d
       - name: Run notebooks
         env:
           DOCKER_BUILDKIT: 1
@@ -33,6 +33,6 @@ jobs:
             echo "Run docker/work/${f}"
 
             # 「UsageError: %%sql is a cell magic, but the cell body is empty. Did you mean the line magic %sql (single %)? 」を許容するため、UsageErrorを許容する設定にしている
-            docker-compose exec -T notebook bash -c "cd work && jupyter nbconvert --to notebook --debug --NotebookClient.allow_error_names UsageError --execute ${f}"
+            docker compose exec -T notebook bash -c "cd work && jupyter nbconvert --to notebook --debug --NotebookClient.allow_error_names UsageError --execute ${f}"
             echo
           done

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Overview
 - 言語によっては向かない設問もあるが、「この言語のときはこう書けば実現できる」という技術習得を目指すことを優先
 - 個人情報のように見える項目は全てダミーデータを利用
 - 大学、企業など組織でのご利用にあたっては、「データサイエンティスト協会スキル定義委員」の「データサイエンス100本ノック（構造化データ加工編）」を利用していることを明示いただければ自由に利用してOK
-- データサイエンス100本ノック(構造化データ加工編)の解説本はこちら 
+- データサイエンス100本ノック(構造化データ加工編)の解説本はこちら
    - https://www.amazon.co.jp/dp/4802613563
 - データサイエンス100本ノック(構造化データ加工編)の利用に関するご質問等について、個別での対応は受けかねますので予めご了承ください
 - データサイエンス100本ノック(構造化データ加工編)の利用により生じるいかなる問題についても、当協会は一切の責任を負いかねますのであらかじめご了承ください
@@ -34,8 +34,8 @@ Install
 ::
 
  git clone git@github.com:The-Japan-DataScientist-Society/100knocks-preprocess.git
- cd 100knocks-preprocess 
- docker-compose up -d --build
+ cd 100knocks-preprocess
+ docker compose up -d --build
 
 ※ macOSでユーザーのホームディレクトリ配下以外にファイル群を配置する場合、Dockerの共有設定が別途必要となります
 
@@ -63,22 +63,22 @@ Link
 ====
 本コンテンツの内容やセットアップ手順について解説いただいているサイト、Dockerについて基本から学べるサイト
 
-- 【データサイエンスを学ぶあなたへ】100本ノック - 構造化データ処理編 - 最速レビュー動画！【データサイエンティスト協会】#062 
+- 【データサイエンスを学ぶあなたへ】100本ノック - 構造化データ処理編 - 最速レビュー動画！【データサイエンティスト協会】#062
    - https://www.youtube.com/watch?v=fAyj0V2iAc4
 
-- データサイエンス100本ノック（構造化データ加工編）を試してみた 
+- データサイエンス100本ノック（構造化データ加工編）を試してみた
    - https://qrunch.net/@hanar/entries/kSZfFS1MXK8H7U7x
 
-- Macでデータサイエンス100本ノックを動かす方法 
+- Macでデータサイエンス100本ノックを動かす方法
    - https://qiita.com/karaage0703/items/1b18b1f4ab65d35afb5f
 
-- さくらのナレッジ 
+- さくらのナレッジ
    - https://knowledge.sakura.ad.jp/13265/
 
-- データサイエンス100本ノックを、Google ColabとAzure Notebooksで気軽に行いたい！ 
+- データサイエンス100本ノックを、Google ColabとAzure Notebooksで気軽に行いたい！
    - https://qiita.com/noguhiro2002/items/de49db61b69c3dbc9282
 
-- データサイエンス初学者にむけた、データサイエンス100本ノックを実装する方法（windows10 Home向け） 
+- データサイエンス初学者にむけた、データサイエンス100本ノックを実装する方法（windows10 Home向け）
    - https://qiita.com/syuki-read/items/714fe66bf5c16b8a7407#comment-394d2f7656bd5b977e11
 
 Author


### PR DESCRIPTION
https://www.docker.com/blog/announcing-compose-v2-general-availability/

docker compose v1 ( `docker-compose` ) が非推奨になったのでv2 ( `docker compose` ) に移行します。