### PR TITLE
CIの処理を問題を解く人の操作に近づける

### DIFF
--- a/.github/workflows/run_notebooks.yml
+++ b/.github/workflows/run_notebooks.yml
@@ -13,20 +13,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Build docker image
-        env:
-          DOCKER_BUILDKIT: 1
-          COMPOSE_DOCKER_CLI_BUILD: 1
-        run: docker-compose build --no-cache
       - name: Run docker containers
-        env:
-          DOCKER_BUILDKIT: 1
-          COMPOSE_DOCKER_CLI_BUILD: 1
         run: docker-compose up -d
       - name: Run notebooks
-        env:
-          DOCKER_BUILDKIT: 1
-          COMPOSE_DOCKER_CLI_BUILD: 1
         run: |
           chmod -R 777 docker/
           for f in $(find docker/work -type f -name "*.ipynb" -not -path "*/.ipynb_checkpoints/*" | sed -e "s:docker/work/::g"); do


### PR DESCRIPTION
CIのDocker関連の処理を問題を解く人がDockerを立ち上げるときの操作に近づけます。
具体的には環境変数と `docker-compose build` の削除を行っています。