### PR TITLE
gitleaksアップデート・Dockleの条件調整

### DIFF
--- a/.github/workflows/dockle.yml
+++ b/.github/workflows/dockle.yml
@@ -35,6 +35,8 @@ jobs:
 
             if [[ "${image_name}" =~ "dss-notebook" ]]; then
               cmd+="--timeout 600s -ae mdf -af settings.py -af credentials -i DKL-DI-0001 "
+            else if [[ "${image_name}" =~ "dss-postgres" ]]; then
+              cmd+="-ak key "
             fi
 
             cmd+="${image_name}"

--- a/.github/workflows/dockle.yml
+++ b/.github/workflows/dockle.yml
@@ -35,7 +35,7 @@ jobs:
 
             if [[ "${image_name}" =~ "dss-notebook" ]]; then
               cmd+="--timeout 600s -ae mdf -af settings.py -af credentials -i DKL-DI-0001 "
-            else if [[ "${image_name}" =~ "dss-postgres" ]]; then
+            elif [[ "${image_name}" =~ "dss-postgres" ]]; then
               cmd+="-ak key "
             fi
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/zricethezav/gitleaks
-    rev: v8.8.11
+    rev: v8.10.2
     hooks:
       - id: gitleaks


### PR DESCRIPTION
CIが通るよう、以下の修正を行います。
* gitleaksアップデート
* ベースイメージ起因のDockleの指摘事項をignoreする