### PR TITLE
postgresアップデート

### DIFF
--- a/docker/db/init/1_init.sql
+++ b/docker/db/init/1_init.sql
@@ -3,3 +3,4 @@ create user padawan password 'padawan12345';
 grant all on database dsdojo_db to padawan;
 grant pg_read_server_files to padawan ;
 grant pg_write_server_files to padawan ;
+alter database dsdojo_db owner to padawan;

--- a/dockerfiles/postgres/Dockerfile
+++ b/dockerfiles/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:14.2-bullseye
+FROM postgres:15.1-bullseye
 
 RUN sed -i -E 's/# (ja_JP.UTF-8)/\1/' /etc/locale.gen \
     && locale-gen \


### PR DESCRIPTION
https://github.com/The-Japan-DataScientist-Society/100knocks-preprocess/pull/181 をベースにpostgresをアップデートします。
初期化クエリにDBのオーナーを指定するクエリを追加しています (参考: https://dev.classmethod.jp/articles/postgresql-15-revoke-create-on-public-schema/ )。