### PR TITLE
[fix] M1/M2 Mac で Docker コンテナを起動できるよう修正

### DIFF
--- a/dockerfiles/notebook/Dockerfile
+++ b/dockerfiles/notebook/Dockerfile
@@ -1,9 +1,19 @@
 FROM jupyter/datascience-notebook:python-3.10.6
 #FROM jupyter/datascience-notebook:d53a302fbcd0
 USER root
+ENV DEBCONF_NOWARNINGS yes
 
-# mambaでR依存パッケージをインストール
-RUN mamba install --quiet --yes r-themis==0.1.4 r-rpostgresql==0.6_2 \
+# 最新のpostgresqlへの対応を行っている (参考: https://www.postgresql.org/download/linux/ubuntu/ )
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends lsb-release gnupg \
+    && sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' \
+    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends libpq-dev \
+    && apt-get remove -y lsb-release gnupg \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/* \
     && find / -type f -perm /u+s -ignore_readdir_race -exec chmod u-s {} \; \
     && find / -type f -perm /g+s -ignore_readdir_race -exec chmod g-s {} \;
 
@@ -14,6 +24,7 @@ COPY Pipfile.lock .
 
 RUN pip install --no-cache-dir pipenv==2021.5.29 \
     && pipenv install --system \
+    && Rscript -e "install.packages(c('DBI', 'RPostgreSQL', 'themis'), dependencies = TRUE, error = TRUE, repos='https://cran.microsoft.com/snapshot/2022-12-16/')" \
     && rm -rf Pipfile* /tmp/* /var/tmp/*
 
 HEALTHCHECK --interval=5s --retries=20 CMD ["curl", "-s", "-S", "-o", "/dev/null", "http://localhost:8888"]


### PR DESCRIPTION
## 環境

- Apple M2 Mac, macOS Ventura
- Docker Desktop: 4.15.0
- Compose: v2.13.0

## 事象

M1/M2 Mac で docker compose build すると、mamba install 時に以下のようなエラーに遭遇し、コンテナのビルド・起動に失敗します。

```
Encountered problems while solving:
  - nothing provides requested r-rpostgresql 0.6_2
  - nothing provides r-rann needed by r-themis-0.1.4-r40hc72bb7e_0
```

M1 Mac で同様の事象に遭遇している方が他にもいらっしゃるようです。
https://magicode.io/kabukiage/articles/51f07474b6bd45c0aee50d5da223481b

## 修正概要

blame を辿ったところ、Rscript から mamba に移行したコミット https://github.com/The-Japan-DataScientist-Society/100knocks-preprocess/commit/0f7df50067ba431568c918af4331124e4bb8a8cc を見つけたため、ほぼ revert するような
形を取ってみました（mamba への移行はビルド時間短縮が目的ですので mamba を生かした修正が最適ですが、上手い方法が見つからず……）。

## 動作確認

```
$ docker compose up -d --build --wait
...
 => [dss-notebook 6/6] RUN pip install --no-cache-dir pipenv==2021.5.29     && pipenv install --system     && rm -rf Pipfile*     && Rscript -e "install.packages(c('DBI', 'RPostgreSQL', 'themis'), dependencies = TRUE, error = TRUE, repos='https://cran.  210.6s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
[+] Running 2/2
 ⠿ Container dss-postgres  Healthy                                                                                                                                                                                                                              6.6s
 ⠿ Container dss-notebook  Healthy                                                                                                                                                                                                                             11.5s
```