### PR TITLE
不要なDockerfileをDockerイメージから削除する

### DIFF
--- a/dockerfiles/notebook/Dockerfile
+++ b/dockerfiles/notebook/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends libpq-dev \
     && apt-get remove -y lsb-release gnupg \
     && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /var/lib/apt/lists/* /opt/julia-*/share/julia/stdlib/v*/SuiteSparse/.devcontainer/Dockerfile \
     && find / -type f -perm /u+s -ignore_readdir_race -exec chmod u-s {} \; \
     && find / -type f -perm /g+s -ignore_readdir_race -exec chmod g-s {} \;
 


### PR DESCRIPTION
https://github.com/The-Japan-DataScientist-Society/100knocks-preprocess/actions/runs/3723572651/jobs/6315166805

```
INFO	- DKL-LI-0003: Only put necessary files
	* unnecessary file : opt/julia-1.8.3/share/julia/stdlib/v1.8/SuiteSparse/.devcontainer/Dockerfile 
```

上記を解消するため、不要なDockerfileをDockerイメージから削除します。