### PR TITLE
RMariaDBのインストールエラー解消

### DIFF
--- a/dockerfiles/notebook/Dockerfile
+++ b/dockerfiles/notebook/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
     && sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' \
     && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && apt-get update \
-    && apt-get install -y --no-install-recommends libpq-dev \
+    && apt-get install -y --no-install-recommends libpq-dev libmariadb-dev \
     && apt-get remove -y lsb-release gnupg \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* /opt/julia-*/share/julia/stdlib/v*/SuiteSparse/.devcontainer/Dockerfile \


### PR DESCRIPTION
https://github.com/The-Japan-DataScientist-Society/100knocks-preprocess/actions/runs/3723681041/jobs/6315345244

```
#18 80.18 -----------------------------[ ANTICONF ]-----------------------------
#18 80.18 Configure could not find suitable mysql/mariadb client library. Try installing:
#18 80.18  * deb: libmariadb-dev (Debian, Ubuntu)
#18 80.18  * rpm: mariadb-connector-c-devel | mariadb-devel | mysql-devel (Fedora, CentOS, RHEL)
#18 80.18  * csw: mysql56_dev (Solaris)
#18 80.18  * brew: mariadb-connector-c (OSX)
#18 80.18 If you already have a mysql client library installed, verify that either
#18 80.18 mariadb_config or mysql_config is on your PATH. If these are unavailable
#18 80.18 you can also set INCLUDE_DIR and LIB_DIR manually via:
#18 80.18 R CMD INSTALL --configure-vars='INCLUDE_DIR=... LIB_DIR=...'
#18 80.18 --------------------------[ ERROR MESSAGE ]----------------------------
#18 80.18 <stdin>:1:10: fatal error: mysql.h: No such file or directory
#18 80.18 compilation terminated.
#18 80.18 -----------------------------------------------------------------------
#18 80.18 ERROR: configuration failed for package ‘RMariaDB’
```

上記エラーを解消するため、 `libmariadb-dev` をインストールします。