### PR TITLE
PostgreSQLインストール時の認証キー取得処理修正

### DIFF
--- a/dockerfiles/notebook/Dockerfile
+++ b/dockerfiles/notebook/Dockerfile
@@ -7,8 +7,8 @@ ENV DEBCONF_NOWARNINGS yes
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update \
     && apt-get install -y --no-install-recommends lsb-release gnupg \
-    && sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' \
-    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/postgres-archive-keyring.gpg \
+    && sh -c 'echo "deb [signed-by=/usr/share/keyrings/postgres-archive-keyring.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' \
     && apt-get update \
     && apt-get install -y --no-install-recommends libpq-dev \
     && apt-get remove -y lsb-release gnupg \


### PR DESCRIPTION
https://github.com/The-Japan-DataScientist-Society/100knocks-preprocess/actions/runs/3723681041/jobs/6315345244

```
Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
```

上記を解消するため、PostgreSQLインストール時の認証キー取得処理を `apt-key` を使わない形式にします。
参考: https://techracho.bpsinc.jp/hachi8833/2022_01_11/114803