### PR TITLE
同じネットワーク内の他の端末からアクセスできないようにする

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     image: dss-postgres
     container_name: dss-postgres
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres12345
@@ -26,7 +26,7 @@ services:
     image: dss-notebook
     container_name: dss-notebook
     ports:
-      - "8888:8888"
+      - "127.0.0.1:8888:8888"
     environment:
       - PG_PORT=5432
       - PG_USER=padawan


### PR DESCRIPTION
https://jun-networks.hatenablog.com/entry/2023/07/03/190000

ポートマッピングに公開先のIPアドレスを明記することで、同じネットワーク内の他の端末からアクセスできないようにします。