### PR TITLE
jupyter/datascience-notebookアップデート

### DIFF
--- a/docker/doc/answer/ans_preprocess_knock_R.html
+++ b/docker/doc/answer/ans_preprocess_knock_R.html
@@ -17434,7 +17434,7 @@ The following objects are masked from ‘package:recipes’:
 
 <span class="n">df_product_tmp</span><span class="p">[</span><span class="s">&quot;key&quot;</span><span class="p">]</span> <span class="o">&lt;-</span> <span class="m">0</span>
 
-<span class="nf">nrow</span><span class="p">(</span><span class="nf">full_join</span><span class="p">(</span><span class="n">df_store_tmp</span><span class="p">,</span> <span class="n">df_product_tmp</span><span class="p">,</span> <span class="n">by</span> <span class="o">=</span> <span class="s">&quot;key&quot;</span><span class="p">))</span>
+<span class="nf">nrow</span><span class="p">(</span><span class="nf">full_join</span><span class="p">(</span><span class="n">df_store_tmp</span><span class="p">,</span><span class="w"> </span><span class="n">df_product_tmp</span><span class="p">,</span><span class="w"> </span><span class="n">by</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="s">"key"</span><span class="p">,</span><span class="w"> </span><span class="n">relationship</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="s">"many-to-many"</span><span class="p">))</span>
 </pre></div>
 
      </div>

--- a/docker/work/answer/ans_preprocess_knock_R.ipynb
+++ b/docker/work/answer/ans_preprocess_knock_R.ipynb
@@ -4602,7 +4602,7 @@
     "\n",
     "df_product_tmp[\"key\"] <- 0\n",
     "\n",
-    "nrow(full_join(df_store_tmp, df_product_tmp, by = \"key\"))"
+    "nrow(full_join(df_store_tmp, df_product_tmp, by = \"key\", relationship = \"many-to-many\"))"
    ]
   },
   {
@@ -10690,7 +10690,7 @@
    "mimetype": "text/x-r-source",
    "name": "R",
    "pygments_lexer": "r",
-   "version": "4.2.2"
+   "version": "4.3.1"
   }
  },
  "nbformat": 4,

--- a/dockerfiles/notebook/Dockerfile
+++ b/dockerfiles/notebook/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/datascience-notebook:python-3.10.8
+FROM jupyter/datascience-notebook:python-3.11.5
 #FROM jupyter/datascience-notebook:d53a302fbcd0
 USER root
 ENV DEBCONF_NOWARNINGS yes


### PR DESCRIPTION
https://github.com/The-Japan-DataScientist-Society/100knocks-preprocess/pull/230 をベースに `jupyter/datascience-notebook` をアップデートします。

また、R-040において以下のWarningが出ていたため、多対多のjoinであることを示す引数を `full_join` に与えています。

```
Warning message in full_join(df_store_tmp, df_product_tmp, by = "key"):
“Detected an unexpected many-to-many relationship between `x` and `y`.
ℹ Row 1 of `x` matches multiple rows in `y`.
ℹ Row 1 of `y` matches multiple rows in `x`.
ℹ If a many-to-many relationship is expected, set `relationship =
  "many-to-many"` to silence this warning.”
```

