### PR TITLE
Dockle修正

### DIFF
--- a/.github/workflows/dockle.yml
+++ b/.github/workflows/dockle.yml
@@ -30,8 +30,9 @@ jobs:
       - name: Run Dockle
         run: |
           for image_name in $(docker compose images | awk 'OFS=":" {print $2,$3}' | tail -n +2); do
-            cmd="docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd)/.dockleignore:/.dockleignore "
-            cmd+="goodwithtech/dockle:${{ steps.get_latest_dockle_version.outputs.result }} --exit-code 1 --exit-level info "
+            docker save "${image_name}" | gzip > image.tar.gz
+            cmd="docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd)/.dockleignore:/.dockleignore -v $(pwd)/image.tar.gz:/image.tar.gz "
+            cmd+="goodwithtech/dockle:${{ steps.get_latest_dockle_version.outputs.result }} --exit-code 1 --exit-level info --input /image.tar.gz "
 
             if [[ "${image_name}" =~ "dss-notebook" ]]; then
               cmd+="--timeout 600s -ae mdf -af settings.py -af credentials -i DKL-DI-0001 "

--- a/dockerfiles/notebook/Dockerfile
+++ b/dockerfiles/notebook/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends libpq-dev libmariadb-dev \
     && apt-get remove -y lsb-release gnupg \
     && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/* /opt/julia-*/share/julia/stdlib/v*/SuiteSparse/.devcontainer/Dockerfile /opt/julia/packages/Pluto/kxeso/.vscode/ \
+    && rm -rf /var/lib/apt/lists/* /opt/julia-*/share/julia/stdlib/v*/SuiteSparse/.devcontainer/Dockerfile /opt/julia/packages/Pluto/*/.vscode/ \
     && find / -type f -perm /u+s -ignore_readdir_race -exec chmod u-s {} \; \
     && find / -type f -perm /g+s -ignore_readdir_race -exec chmod g-s {} \;
 


### PR DESCRIPTION
DockleでローカルのDockerイメージを読ませようとすると、レジストリにアクセスしようとするケースがあるので、Dockerイメージをtar.gz経由でDockleに渡すように修正します。

https://github.com/The-Japan-DataScientist-Society/100knocks-preprocess/actions/runs/6386997179/job/17334633090?pr=237

```
INFO	- DKL-LI-0003: Only put necessary files
	* Suspicious directory : opt/julia/packages/Pluto/dMZ7o/.vscode 
```

また、Dockerイメージ生成時に削除するファイルのパス指定を緩くして、より確実に削除されるようにしています。