### PR TITLE
Rパッケージを直接インストールする形に戻す

### DIFF
--- a/dockerfiles/notebook/Dockerfile
+++ b/dockerfiles/notebook/Dockerfile
@@ -22,11 +22,9 @@ WORKDIR /home/jovyan
 COPY Pipfile .
 COPY Pipfile.lock .
 
-# hadolint ignore=SC2016
 RUN pip install --no-cache-dir pipenv==2021.5.29 \
     && pipenv install --system \
-    && Rscript -e 'install.packages("pak", repos = sprintf("https://r-lib.github.io/p/pak/stable/%s/%s/%s", .Platform$pkgType, R.Version()$os, R.Version()$arch))' \
-    && Rscript -e 'pak::repo_add(CRAN = "RSPM@2022-12-16"); pak::pak(c("DBI", "RPostgreSQL", "themis"))' \
+    && Rscript -e 'install.packages(c("DBI", "RPostgreSQL", "themis"), dependencies = TRUE, error = TRUE, repos="https://cran.r-project.org")' \
     && rm -rf Pipfile* .cache/R/pkgcache/sysreqs/docker/*/Dockerfile /tmp/* /var/tmp/*
 
 HEALTHCHECK --interval=5s --retries=20 CMD ["curl", "-s", "-S", "-o", "/dev/null", "http://localhost:8888"]


### PR DESCRIPTION
https://github.com/The-Japan-DataScientist-Society/100knocks-preprocess/blob/dad39e32ed46e4e9e7e8ae0bb0e2bd14e0e07e7c/dockerfiles/notebook/Dockerfile#L27

Rパッケージのインストール方法を上記時点に事実上戻します。