### PR TITLE
jupyter/datascience-notebookをquay.io経由で取得する

### DIFF
--- a/dockerfiles/notebook/Dockerfile
+++ b/dockerfiles/notebook/Dockerfile
@@ -26,6 +26,6 @@ COPY install.R .
 RUN pip install --no-cache-dir pipenv==2021.5.29 \
     && pipenv install --system \
     && Rscript install.R \
-    && rm -rf Pipfile* install.R .cache/R/pkgcache/sysreqs/docker/*/Dockerfile /tmp/* /var/tmp/*
+    && rm -rf Pipfile* install.R .cache/R/pkgcache/sysreqs/docker/*/Dockerfile /tmp/* /var/tmp/* .npm/
 
 HEALTHCHECK --interval=5s --retries=20 CMD ["curl", "-s", "-S", "-o", "/dev/null", "http://localhost:8888"]


### PR DESCRIPTION
https://github.com/jupyter/docker-stacks/tree/main/images/datascience-notebook

>**Images hosted on Docker Hub are no longer updated. Please, use [quay.io image](https://quay.io/repository/jupyter/datascience-notebook)**

`jupyter/datascience-notebook` のDocker Hub経由のイメージは更新されないようなので、ベースイメージを https://quay.io/ 経由に変更します。
また、Pythonを3.11の最新バージョンにアップデートします。