### PR TITLE
docker-compose.yml: version削除

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   db:
     build:


### PR DESCRIPTION
```
$ docker compose up
WARN[0000] /path/to/100knocks-preprocess/docker-compose.yml: `version` is obsolete 
```

`version` は廃止されたとのことなので、 `docker-compose.yml` から削除します。