### PR TITLE
README: 説明文字列をリンクにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 - 言語によっては向かない設問もあるが、「この言語のときはこう書けば実現できる」という技術習得を目指すことを優先
 - 個人情報のように見える項目は全てダミーデータを利用
 - 大学、企業など組織でのご利用にあたっては、「データサイエンティスト協会スキル定義委員」の「データサイエンス100本ノック（構造化データ加工編）」を利用していることを明示いただければ自由に利用してOK
-- データサイエンス100本ノック(構造化データ加工編)の解説本はこちら
-  - [https://www.amazon.co.jp/dp/4802613563](https://www.amazon.co.jp/dp/4802613563)
+- データサイエンス100本ノック(構造化データ加工編)の[解説本](https://www.amazon.co.jp/dp/4802613563)が販売されています
 - データサイエンス100本ノック(構造化データ加工編)の利用に関するご質問等について、個別での対応は受けかねますので予めご了承ください
 - データサイエンス100本ノック(構造化データ加工編)の利用により生じるいかなる問題についても、当協会は一切の責任を負いかねますのであらかじめご了承ください
 
@@ -66,23 +65,17 @@ docker compose up -d --build --wait
 ## Link
 本コンテンツの内容やセットアップ手順について解説いただいているサイト、Dockerについて基本から学べるサイト
 
-- 【データサイエンスを学ぶあなたへ】100本ノック - 構造化データ処理編 - 最速レビュー動画！【データサイエンティスト協会】#062
-  - [https://www.youtube.com/watch?v=fAyj0V2iAc4](https://www.youtube.com/watch?v=fAyj0V2iAc4)
+- [【データサイエンスを学ぶあなたへ】100本ノック - 構造化データ処理編 - 最速レビュー動画！【データサイエンティスト協会】#062](https://www.youtube.com/watch?v=fAyj0V2iAc4)
 
-- データサイエンス100本ノック（構造化データ加工編）を試してみた
-  - [https://qrunch.net/@hanar/entries/kSZfFS1MXK8H7U7x](https://qrunch.net/@hanar/entries/kSZfFS1MXK8H7U7x)
+- [データサイエンス100本ノック（構造化データ加工編）を試してみた](https://qrunch.net/@hanar/entries/kSZfFS1MXK8H7U7x)
 
-- Macでデータサイエンス100本ノックを動かす方法
-  - [https://qiita.com/karaage0703/items/1b18b1f4ab65d35afb5f](https://qiita.com/karaage0703/items/1b18b1f4ab65d35afb5f)
+- [Macでデータサイエンス100本ノックを動かす方法](https://qiita.com/karaage0703/items/1b18b1f4ab65d35afb5f)
 
-- さくらのナレッジ
-  - [https://knowledge.sakura.ad.jp/13265/](https://knowledge.sakura.ad.jp/13265/)
+- [さくらのナレッジ](https://knowledge.sakura.ad.jp/13265/)
 
-- データサイエンス100本ノックを、Google ColabとAzure Notebooksで気軽に行いたい！
-  - [https://qiita.com/noguhiro2002/items/de49db61b69c3dbc9282](https://qiita.com/noguhiro2002/items/de49db61b69c3dbc9282)
+- [データサイエンス100本ノックを、Google ColabとAzure Notebooksで気軽に行いたい！](https://qiita.com/noguhiro2002/items/de49db61b69c3dbc9282)
 
-- データサイエンス初学者にむけた、データサイエンス100本ノックを実装する方法（windows10 Home向け）
-  - [https://qiita.com/syuki-read/items/714fe66bf5c16b8a7407#comment-394d2f7656bd5b977e11](https://qiita.com/syuki-read/items/714fe66bf5c16b8a7407#comment-394d2f7656bd5b977e11)
+- [データサイエンス初学者にむけた、データサイエンス100本ノックを実装する方法（windows10 Home向け）](https://qiita.com/syuki-read/items/714fe66bf5c16b8a7407#comment-394d2f7656bd5b977e11)
 
 ## Author
 The Data Scientist Society


### PR DESCRIPTION
サイトの説明文字列とURLを別々に記述するより、説明文字列をリンクにした方がアクセシビリティーが向上しそうなので、そのように修正します。